### PR TITLE
Adding zjet into plotting scripts

### DIFF
--- a/scripts/plot.py
+++ b/scripts/plot.py
@@ -99,7 +99,7 @@ def main():
     
     # cluster_breit(dataloaders, store_all_jets = flags.plot_zjet)
     cluster_jets(dataloaders, store_all_jets = flags.plot_zjet)
-    cluster_breit(dataloaders, clustering_algorithm="kt", store_all_jets = flags.plot_zjet)
+    cluster_breit(dataloaders, store_all_jets = flags.plot_zjet)
     gather_data(dataloaders, store_all_jets = flags.plot_zjet)
     plot_particles(flags,dataloaders,weights,opt['NAME'],num_part = num_part)
     plot_jet_pt(flags,dataloaders,weights,opt['NAME'],lab_frame=False)
@@ -107,8 +107,8 @@ def main():
     
     plot_deltaphi(flags,dataloaders,weights,opt['NAME'])
     plot_tau(flags,dataloaders,weights,opt['NAME'])
-    plot_zjet(flags,dataloaders,weights,opt['NAME'], frame = "lab", clustering = "kt")
-    plot_zjet(flags,dataloaders,weights,opt['NAME'], frame = "breit", clustering = "centauro")
+    plot_zjet(flags,dataloaders,weights,opt['NAME'], frame = "lab")
+    plot_zjet(flags,dataloaders,weights,opt['NAME'], frame = "breit")
     plot_event(flags,dataloaders,weights,opt['NAME'])    
 
 

--- a/scripts/plot.py
+++ b/scripts/plot.py
@@ -31,7 +31,6 @@ def parse_arguments():
     parser.add_argument('--blind', action='store_true', default=False,help='Show the results based on closure instead of data')
     #parser.add_argument('--closure', action='store_true', default=False,help='Plot closure results')
     parser.add_argument('--niter', type=int, default=0, help='Omnifold iteration to load')
-    parser.add_argument('--plot_zjet', action='store_true', default=False, help='Plot zjet using all jets')
     parser.add_argument('--nmax', type=int, default=1000000, help='Maximum number of events to load')
     parser.add_argument('--img_fmt', default='pdf', help='Format of the output figures')
     parser.add_argument('--verbose', action='store_true', default=False,help='Increase print level')
@@ -97,10 +96,9 @@ def main():
     undo_standardizing(flags,dataloaders)
     num_part = dataloaders['Rapgap'].part.shape[1]
     
-    # cluster_breit(dataloaders, store_all_jets = flags.plot_zjet)
-    cluster_jets(dataloaders, store_all_jets = flags.plot_zjet)
-    cluster_breit(dataloaders, store_all_jets = flags.plot_zjet)
-    gather_data(dataloaders, store_all_jets = flags.plot_zjet)
+    cluster_jets(dataloaders)
+    cluster_breit(dataloaders)
+    gather_data(dataloaders)
     plot_particles(flags,dataloaders,weights,opt['NAME'],num_part = num_part)
     plot_jet_pt(flags,dataloaders,weights,opt['NAME'],lab_frame=False)
     plot_jet_pt(flags,dataloaders,weights,opt['NAME'])

--- a/scripts/plot.py
+++ b/scripts/plot.py
@@ -31,6 +31,7 @@ def parse_arguments():
     parser.add_argument('--blind', action='store_true', default=False,help='Show the results based on closure instead of data')
     #parser.add_argument('--closure', action='store_true', default=False,help='Plot closure results')
     parser.add_argument('--niter', type=int, default=0, help='Omnifold iteration to load')
+    parser.add_argument('--plot_zjet', action='store_true', default=False, help='Plot zjet using all jets')
     parser.add_argument('--nmax', type=int, default=2500000, help='Maximum number of events to load')
     parser.add_argument('--img_fmt', default='pdf', help='Format of the output figures')
     parser.add_argument('--verbose', action='store_true', default=False,help='Increase print level')
@@ -80,7 +81,6 @@ def main():
         print(f'Will load the following files : {mc_files.keys()}')
         
     dataloaders = get_dataloaders(flags,mc_files)
-
     weights = {}
     for dataset in dataloaders:
         if flags.verbose and hvd.rank()==0:
@@ -97,15 +97,18 @@ def main():
     undo_standardizing(flags,dataloaders)
     num_part = dataloaders['Rapgap'].part.shape[1]
     
-    cluster_breit(dataloaders)
-    cluster_jets(dataloaders)
-    gather_data(dataloaders)
+    # cluster_breit(dataloaders, store_all_jets = flags.plot_zjet)
+    cluster_jets(dataloaders, store_all_jets = flags.plot_zjet)
+    cluster_breit(dataloaders, clustering_algorithm="kt", store_all_jets = flags.plot_zjet)
+    gather_data(dataloaders, store_all_jets = flags.plot_zjet)
     plot_particles(flags,dataloaders,weights,opt['NAME'],num_part = num_part)
     plot_jet_pt(flags,dataloaders,weights,opt['NAME'],lab_frame=False)
     plot_jet_pt(flags,dataloaders,weights,opt['NAME'])
     
     plot_deltaphi(flags,dataloaders,weights,opt['NAME'])
     plot_tau(flags,dataloaders,weights,opt['NAME'])
+    plot_zjet(flags,dataloaders,weights,opt['NAME'], frame = "lab", clustering = "kt")
+    plot_zjet(flags,dataloaders,weights,opt['NAME'], frame = "breit", clustering = "centauro")
     plot_event(flags,dataloaders,weights,opt['NAME'])    
 
 

--- a/scripts/plot_from_file.py
+++ b/scripts/plot_from_file.py
@@ -13,7 +13,7 @@ import h5py as h5
 utils.SetStyle()
 
 var_names = ['weights','mc_weights','jet_pt',
-             'jet_breit_pt','deltaphi','jet_tau10']
+             'jet_breit_pt','deltaphi','jet_tau10', 'zjet', 'zjet_breit']
 
 
 def get_sample_names(niter, use_sys, sys_list = ['sys0','sys1','sys5','sys7','sys11'],

--- a/scripts/plot_utils.py
+++ b/scripts/plot_utils.py
@@ -6,6 +6,9 @@ import tensorflow as tf
 import utils
 import horovod.tensorflow as hvd
 import warnings
+import awkward as ak
+import uproot
+import subprocess
 
 def get_sample_names(use_sys, sys_list = ['sys0','sys1','sys5','sys7','sys11'],
                      nominal = 'Rapgap',period = 'Eplus0607'):
@@ -82,7 +85,7 @@ def undo_standardizing(flags,dataloaders):
 
 
 
-def cluster_jets(dataloaders):
+def cluster_jets(dataloaders, store_all_jets = False):
     """
     Update dataloaders with clustered jet information.
 
@@ -103,8 +106,34 @@ def cluster_jets(dataloaders):
         new_particles[:, :, 3] = np.ma.exp(part[:, :, 5])
 
         return new_particles * mask[:, :, None]
+    
+    def _convert_electron_kinematics(event_list):
+        pt = event_list[:, 2]*np.sqrt(np.exp(event_list[:, 0]))
+        phi = event_list[:, 4]
+        eta = event_list[:, 3]
+        px = pt * np.cos(phi)
+        py = pt * np.sin(phi)
+        pz = pt * np.sinh(eta)
+        E = np.sqrt(px**2 + py**2 + pz**2)
+        electron_cartesian_dict = {"px":px, "py":py, "pz":pz, "E":E}
+        return electron_cartesian_dict
+    
+    def _calculate_q(final_states, scattered_electron):
+        sigma_h = np.array([np.sum(event[:, 3] - event[:, 2]) for event in final_states if any(np.abs(event[:, 0]) != 0)])
+        scattered_electron_momentum = np.sqrt(scattered_electron["px"]**2 + scattered_electron["py"]**2 + scattered_electron["pz"]**2)
+        scattered_electron_theta = np.arccos(scattered_electron["pz"]/scattered_electron_momentum)
+        sigma_eprime = scattered_electron["E"] * (1 - np.cos(scattered_electron_theta))
+        sigma_tot = sigma_h + sigma_eprime
+        beam_electron_momentum = {"px":np.zeros(len(sigma_tot)), "py":np.zeros(len(sigma_tot)), "pz":-sigma_tot/2., "E":sigma_tot/2.}
+        q_x = beam_electron_momentum["px"] - scattered_electron["px"]
+        q_y = beam_electron_momentum["py"] - scattered_electron["py"]
+        q_z = beam_electron_momentum["pz"] - scattered_electron["pz"]
+        q_E = beam_electron_momentum["E"] - scattered_electron["E"]
+        q_list = np.stack((q_x, q_y, q_z, q_E), axis=1)
+        return q_list
+    
+    def _calculate_jet_features(jet, q):
 
-    def _calculate_jet_features(jet):
         """Calculate jet features such as tau variables and ptD."""
         tau_11, tau_11p5, tau_12, tau_20, sumpt = 0, 0, 0, 0, 0
         for constituent in jet.constituents():
@@ -123,12 +152,18 @@ def cluster_jets(dataloaders):
         jet.tau_20 = tau_20 / (jet.pt() ** 2)
         jet.ptD = np.sqrt(tau_20) / sumpt
 
+        # Calculating zjet
+        P = np.array([0, 0, 920, 920], dtype=np.float32) # 920 GeV is proton beam energy
+        P_dot_q = P[3]*q[3] - P[0]*q[0] - P[1]*q[1] - P[2]*q[2]
+        z_jet_numerator = P[3]*jet.E() - P[0]*jet.px() - P[1]*jet.py() - P[2]*jet.pz()
+        jet.zjet = z_jet_numerator/P_dot_q
+        
 
         
     def _take_leading_jet(jets):
         """Extract features of the leading jet."""
         if not jets:
-            return np.zeros(9)
+            return np.zeros(10)
 
         leading_jet = jets[0]
         return np.array([
@@ -140,7 +175,27 @@ def cluster_jets(dataloaders):
             leading_jet.tau_11p5,
             leading_jet.tau_12,
             leading_jet.tau_20,
-            leading_jet.ptD
+            leading_jet.ptD,
+            leading_jet.zjet
+        ])
+    
+    def _take_all_jets(jets):
+        if not jets:
+            return np.zeros((0, 10))
+    
+        return np.array([
+            [
+                jet.pt(),
+                jet.eta(),
+                (jet.phi() + np.pi) % (2 * np.pi) - np.pi,
+                jet.E(),
+                jet.tau_11,
+                jet.tau_11p5,
+                jet.tau_12,
+                jet.tau_20,
+                jet.ptD,
+                jet.zjet
+            ] for jet in jets
         ])
 
     for dataloader_name, data in dataloaders.items():
@@ -148,10 +203,12 @@ def cluster_jets(dataloaders):
 
         # Convert particles to Cartesian coordinates
         cartesian = _convert_kinematics(data.part, data.event, data.mask)
-
+        electron_momentum = _convert_electron_kinematics(data.event)
+        # print(cartesian)
+        q = _calculate_q(cartesian, electron_momentum)
         list_of_jets = []
-
-        for event in cartesian:
+        list_of_all_jets = []
+        for i, event in enumerate(cartesian):
             particles = [
                 fastjet.PseudoJet(p[0], p[1], p[2], p[3])
                 for p in event if np.abs(p[0]) != 0
@@ -162,14 +219,21 @@ def cluster_jets(dataloaders):
             sorted_jets = fastjet.sorted_by_pt(cluster.inclusive_jets(ptmin=10))
             # Calculate jet features
             for jet in sorted_jets:
-                _calculate_jet_features(jet)
+                _calculate_jet_features(jet, q[i])
 
             # Take the leading jet's features
             leading_jet = _take_leading_jet(sorted_jets)
             list_of_jets.append(leading_jet)
-
+            if store_all_jets:
+                all_jets = _take_all_jets(sorted_jets)
+                list_of_all_jets.append(all_jets)
         # Store the jet features in the dataloader
         data.jet = np.array(list_of_jets, dtype=np.float32)
+        if store_all_jets:
+            max_len = max(ak.num(list_of_all_jets, axis=1))
+            padded_jets = ak.pad_none(list_of_all_jets, target=max_len, axis=1)
+            numpy_padded_jets = ak.to_numpy(ak.fill_none(padded_jets, np.zeros(10)))
+            data.all_jets = numpy_padded_jets
         #print(f"----------------- Done working with {dataloader_name} -------------------")
 
 
@@ -622,8 +686,116 @@ def plot_tau(flags, dataloaders, data_weights, version):
     ax.set_ylim(0, 1.2)
     fig.savefig(f'../plots/{version}_jet_tau10.pdf')
 
+def plot_zjet(flags, dataloaders, data_weights, version, frame = "lab", clustering = "kt"):
+    import numpy as np
+    import utils
 
-def cluster_breit(dataloaders):
+    def compute_histogram(dataset_name, weights=None, frame="lab"):
+        if frame == "breit":
+            num_jets_per_event = ak.count(dataloaders[dataset_name].all_jets["zjet"], axis=1)
+            data = ak.flatten(dataloaders[dataset_name].all_jets["zjet"][num_jets_per_event>0])
+        else:
+            num_jets_per_event = ak.count(dataloaders[dataset_name].all_jets_breit["zjet"], axis=1)
+            data = ak.flatten(dataloaders[dataset_name].all_jets_breit["zjet"][num_jets_per_event>0])
+        if weights is not None:
+            weights = np.repeat(weights, num_jets_per_event, axis=0)
+        return np.histogram(data, bins=binning, density=True, weights=weights)
+
+    # Determine weight name
+    weight_name = 'closure' if flags.blind else 'Rapgap'
+    data_name = 'Rapgap_closure' if flags.blind else 'Rapgap_unfolded'
+
+    # Set binning
+    binning = np.linspace(0.2, 1, 10)
+    # Compute nominal and closure histograms if systematic uncertainties are enabled
+    total_unc = None
+    if flags.sys:
+        nominal, _ = compute_histogram('Rapgap', dataloaders['Rapgap'].weight * data_weights['Rapgap'], frame)
+        nominal_closure, _ = compute_histogram('Djangoh', dataloaders['Djangoh'].weight, frame)
+
+        total_unc = np.zeros_like(nominal)
+        for sys, sys_weights in data_weights.items():
+            if sys == 'Rapgap':
+                continue
+
+            sample_name = 'Rapgap' if sys == 'closure' else sys
+            sys_hist, _ = compute_histogram(sample_name, dataloaders[sample_name].weight * sys_weights, frame)
+
+            ref_hist = nominal_closure if sys == 'closure' else nominal
+            unc = (np.ma.divide(sys_hist, ref_hist).filled(1) - 1) ** 2
+            total_unc += unc
+
+            print(f"{sys}: max uncertainty = {np.max(np.sqrt(unc))}")
+
+        total_unc = np.sqrt(total_unc)
+
+    # Prepare weights and data for plotting
+
+    if frame == "breit":
+        num_Rapgap_jets_per_event = ak.count(dataloaders["Rapgap"].all_jets_breit["zjet"], axis=1)
+        num_Djangoh_jets_per_event = ak.count(dataloaders["Djangoh"].all_jets_breit["zjet"], axis=1)
+        weights = {
+            data_name: np.repeat((dataloaders['Rapgap'].weight * data_weights[weight_name]), num_Rapgap_jets_per_event, axis=0),
+            'Rapgap': np.repeat(dataloaders['Rapgap'].weight, num_Rapgap_jets_per_event, axis=0),
+            'Djangoh': np.repeat(dataloaders['Djangoh'].weight, num_Djangoh_jets_per_event, axis=0),
+        }
+
+        feed_dict = {
+            data_name: ak.flatten(dataloaders['Rapgap'].all_jets_breit["zjet"][ak.count(dataloaders["Rapgap"].all_jets_breit["zjet"], axis=1) > 0]),
+            'Rapgap': ak.flatten(dataloaders['Rapgap'].all_jets_breit["zjet"][ak.count(dataloaders["Rapgap"].all_jets_breit["zjet"], axis=1) > 0]),
+            'Djangoh': ak.flatten(dataloaders['Djangoh'].all_jets_breit["zjet"][ak.count(dataloaders["Djangoh"].all_jets_breit["zjet"], axis=1) > 0]),
+        }
+
+        if flags.reco:
+            feed_dict['data'] = ak.flatten(dataloaders['data'].all_jets_breit["zjet"][ak.count(dataloaders["data"].all_jets_breit["zjet"], axis=1) > 0])
+    else:
+        num_Rapgap_jets_per_event = ak.count(dataloaders["Rapgap"].all_jets["zjet"], axis=1)
+        num_Djangoh_jets_per_event = ak.count(dataloaders["Djangoh"].all_jets["zjet"], axis=1)
+        weights = {
+            data_name: np.repeat((dataloaders['Rapgap'].weight * data_weights[weight_name]), num_Rapgap_jets_per_event, axis=0),
+            'Rapgap': np.repeat(dataloaders['Rapgap'].weight, num_Rapgap_jets_per_event, axis=0),
+            'Djangoh': np.repeat(dataloaders['Djangoh'].weight, num_Djangoh_jets_per_event, axis=0),
+        }
+
+        feed_dict = {
+            data_name: ak.flatten(dataloaders['Rapgap'].all_jets["zjet"][ak.count(dataloaders["Rapgap"].all_jets["zjet"], axis=1) > 0]),
+            'Rapgap': ak.flatten(dataloaders['Rapgap'].all_jets["zjet"][ak.count(dataloaders["Rapgap"].all_jets["zjet"], axis=1) > 0]),
+            'Djangoh': ak.flatten(dataloaders['Djangoh'].all_jets["zjet"][ak.count(dataloaders["Djangoh"].all_jets["zjet"], axis=1) > 0]),
+        }
+
+        if flags.reco:
+            feed_dict['data'] = ak.flatten(dataloaders['data'].all_jets["zjet"][ak.count(dataloaders["data"].all_jets["zjet"], axis=1) > 0])
+
+    # Generate histogram plot
+    if clustering == "centauro":
+        fig, ax = utils.HistRoutine(
+            feed_dict,
+            xlabel=f'$z_{{jet}}$ ({frame.capitalize()} {clustering.capitalize()})',
+            weights=weights,
+            logy=False,
+            logx=False,
+            binning=binning,
+            reference_name='data' if flags.reco else data_name,
+            label_loc='upper left',
+            uncertainty=total_unc,
+        )
+    else:
+        fig, ax = utils.HistRoutine(
+            feed_dict,
+            xlabel=f'$z_{{jet}}$ ({frame.capitalize()} {clustering})',
+            weights=weights,
+            logy=False,
+            logx=False,
+            binning=binning,
+            reference_name='data' if flags.reco else data_name,
+            label_loc='upper left',
+            uncertainty=total_unc,
+        )
+    # Set plot limits and save
+    ax.set_ylim(0, 5)
+    fig.savefig(f'../plots/{version}_zjet_{frame}_{clustering}.pdf')
+
+def cluster_breit(dataloaders, clustering_algorithm = "kt", store_all_jets = False):
     import fastjet
     import awkward as ak
     import vector
@@ -697,7 +869,8 @@ def cluster_breit(dataloaders):
         return boosted_vectors
 
     
-    jetdef = fastjet.JetDefinition(fastjet.kt_algorithm, 1.0)
+    if clustering_algorithm == "kt":
+        jetdef = fastjet.JetDefinition(fastjet.kt_algorithm, 1.0)
     for dataloader_name, data in dataloaders.items():
         
         electron_momentum = _convert_electron_kinematics(data.event)
@@ -707,16 +880,39 @@ def cluster_breit(dataloaders):
 
         for event in boosted_vectors:
             events.append([{"px": part_vec.px, "py": part_vec.py, "pz": part_vec.pz, "E": part_vec.E} for part_vec in event])
+        if clustering_algorithm == "centauro":
+            px, py, pz, energy = [], [], [], []
+            for event in events:
+                px.append([particle_vector["px"] for particle_vector in event])
+                py.append([particle_vector["py"] for particle_vector in event])
+                pz.append([particle_vector["pz"] for particle_vector in event])
+                energy.append([particle_vector["E"] for particle_vector in event])
+            px = ak.Array(px)
+            py = ak.Array(py)
+            pz = ak.Array(pz)
+            energy = ak.Array(energy)
+            with uproot.recreate("./breit_particles.root") as file:
+                file["particles"] = {"px": px, "py": py, "pz": pz, "energy": energy}
 
-        array = ak.Array(events)
-        cluster = fastjet.ClusterSequence(array, jetdef)
-        jets = cluster.inclusive_jets(min_pt=10)
+            breit_file_name = f"breit_particles_{dataloader_name}_gen.root"
+            jet_file_name = f"centauro_jets_{dataloader_name}_gen.root"
+
+            print(f"./run_centauro.sh --input {breit_file_name} --output {jet_file_name} --jet_radius 1.0")
+            exit()
+            subprocess.run([f"./run_centauro.sh --input {breit_file_name} --output {jet_file_name} --jet_radius 1.0"], shell=True)
+            with uproot.open(f"{jet_file_name}:jets") as out:
+                jets = out.arrays(["pt", "eta", "phi", "E", "px", "py", "pz"])
         
-        jets["pt"] = -np.sqrt(jets["px"]**2 + jets["py"]**2)
-        jets["phi"] = np.arctan2(jets["py"],jets["px"])
-        jets["eta"] = np.arcsinh(jets["pz"]/jets["pt"])
-        jets = fastjet.sorted_by_pt(jets)
-        
+        else:
+            array = ak.Array(events)
+            cluster = fastjet.ClusterSequence(array, jetdef)
+            jets = cluster.inclusive_jets(min_pt=10)
+            
+            jets["pt"] = -np.sqrt(jets["px"]**2 + jets["py"]**2)
+            jets["phi"] = np.arctan2(jets["py"],jets["px"])
+            jets["eta"] = np.arcsinh(jets["pz"]/jets["pt"])
+            jets = fastjet.sorted_by_pt(jets)
+        max_num_jets = max([len(jet_pt) for jet_pt in jets["pt"]])
 
         def _take_leading_jet(jets):
             jet = np.zeros((data.event.shape[0],4))
@@ -725,8 +921,20 @@ def cluster_breit(dataloaders):
             jet[:,2] = np.array(list(itertools.zip_longest(*jets.phi.to_list(), fillvalue=0))).T[:,0]
             jet[:,3] = np.array(list(itertools.zip_longest(*jets.E.to_list(), fillvalue=0))).T[:,0]
             return jet
+        def _take_all_jets(jets, max_num_jets):
+            jet = np.zeros((data.event.shape[0], 7, max_num_jets))
+            jet[:,0] = -np.array(list(itertools.zip_longest(*jets.pt.to_list(), fillvalue=0))).T
+            jet[:,1] = np.array(list(itertools.zip_longest(*jets.eta.to_list(), fillvalue=0))).T
+            jet[:,2] = np.array(list(itertools.zip_longest(*jets.phi.to_list(), fillvalue=0))).T
+            jet[:,3] = np.array(list(itertools.zip_longest(*jets.E.to_list(), fillvalue=0))).T
+            jet[:,4] = np.array(list(itertools.zip_longest(*jets.px.to_list(), fillvalue=0))).T
+            jet[:,5] = np.array(list(itertools.zip_longest(*jets.py.to_list(), fillvalue=0))).T
+            jet[:,6] = np.array(list(itertools.zip_longest(*jets.pz.to_list(), fillvalue=0))).T
+            return jet
             
         dataloaders[dataloader_name].jet_breit = _take_leading_jet(jets)
+        if store_all_jets:
+            dataloaders[dataloader_name].all_jets_breit = _take_all_jets(jets, max_num_jets)
 
         
     
@@ -822,7 +1030,9 @@ def plot_event(flags, dataloaders, data_weights, version, nbins=10):
         fig.savefig(f'../plots/{version}_event_{feature}.pdf')        
 
 
-def gather_data(dataloaders):
+def gather_data(dataloaders, store_all_jets = False):
+
+
     for dataloader in dataloaders:
         dataloaders[dataloader].mask = np.reshape(dataloaders[dataloader].mask,(-1))
         dataloaders[dataloader].part = hvd.allgather(tf.constant(dataloaders[dataloader].part.reshape(
@@ -831,6 +1041,37 @@ def gather_data(dataloaders):
         dataloaders[dataloader].event = hvd.allgather(tf.constant(dataloaders[dataloader].event)).numpy()
         dataloaders[dataloader].jet = hvd.allgather(tf.constant(dataloaders[dataloader].jet)).numpy()
         dataloaders[dataloader].jet_breit = hvd.allgather(tf.constant(dataloaders[dataloader].jet_breit)).numpy()
+        if store_all_jets:
+            def mask_jets(jets, mask, frame="lab"):
+                out_dict = {}
+                if frame == "lab":
+                    jet_features = ["pt", "eta", "phi", "E", "tau11", "tau11p5", "tau12", "tau20", "ptD", "zjet"]
+                elif frame == "breit":
+                    jet_features = ["pt", "eta", "phi", "E", "px", "py", "pz"]
+                # Adding the jet observables to the dictionary and removing events that don't pass the mask
+                # The masked events will be replaced with None and then dropped
+                masked_jets = ak.drop_none(ak.mask(jets, mask))
+                for i in range(len(jet_features)):
+                    out_dict[f"{jet_features[i]}"] = masked_jets[:, :, i]
+                return out_dict
+            def calculate_zjet(jet_data, event):
+                Q_array = np.sqrt(np.exp(event[:,0]))
+                n = np.array([0, 0, 1, 1], dtype=np.float32)
+                z_jet = []
+                jet_px = jet_data["px"]
+                jet_py = jet_data["py"]
+                jet_pz = jet_data["pz"]
+                jet_E = jet_data["E"]
+                numerator = n[3]*jet_E- n[0]*jet_px - n[1]*jet_py - n[2]*jet_pz
+                z_jet = ak.drop_none(numerator/Q_array, axis=1)
+                jet_data["zjet"] = z_jet
+            dataloaders[dataloader].all_jets = hvd.allgather(tf.constant(dataloaders[dataloader].all_jets)).numpy()
+            dataloaders[dataloader].all_jets = mask_jets(dataloaders[dataloader].all_jets, ~np.isnan(dataloaders[dataloader].all_jets[:, :, 9]))
+            dataloaders[dataloader].all_jets_breit = hvd.allgather(tf.constant(dataloaders[dataloader].all_jets_breit)).numpy()
+            dataloaders[dataloader].all_jets_breit = dataloaders[dataloader].all_jets_breit.transpose(0, 2, 1)
+            breit_mask = (dataloaders[dataloader].all_jets_breit[:, :, 3]!=0) & (dataloaders[dataloader].all_jets_breit[:, :, 4]!=0)  & (dataloaders[dataloader].all_jets_breit[:, :, 5]!=0) & (dataloaders[dataloader].all_jets_breit[:, :, 6]!=0)
+            dataloaders[dataloader].all_jets_breit = mask_jets(dataloaders[dataloader].all_jets_breit, breit_mask, frame="breit")
+            calculate_zjet(dataloaders[dataloader].all_jets_breit, dataloaders[dataloader].event)
         dataloaders[dataloader].weight = hvd.allgather(tf.constant(dataloaders[dataloader].weight)).numpy()
         dataloaders[dataloader].mask = hvd.allgather(tf.constant(dataloaders[dataloader].mask)).numpy()
 

--- a/scripts/plot_utils.py
+++ b/scripts/plot_utils.py
@@ -697,7 +697,8 @@ def plot_zjet(flags, dataloaders, data_weights, version, frame = "lab", clusteri
             data = ak.flatten(dataloaders[dataset_name].all_jets_breit["zjet"][num_jets_per_event>0])
         if weights is not None:
             weights = np.repeat(weights, num_jets_per_event, axis=0)
-        return np.histogram(data, bins=binning, density=True, weights=weights)
+        counts, bins = np.histogram(data, bins=binning, density=True, weights=weights)
+        return ak.to_numpy(counts), bins
 
     # Determine weight name
     weight_name = 'closure' if flags.blind else 'Rapgap'
@@ -721,6 +722,7 @@ def plot_zjet(flags, dataloaders, data_weights, version, frame = "lab", clusteri
 
             ref_hist = nominal_closure if sys == 'closure' else nominal
             unc = (np.ma.divide(sys_hist, ref_hist).filled(1) - 1) ** 2
+            print(unc, total_unc)
             total_unc += unc
 
             print(f"{sys}: max uncertainty = {np.max(np.sqrt(unc))}")

--- a/scripts/save_unfolded.py
+++ b/scripts/save_unfolded.py
@@ -31,7 +31,6 @@ def parse_arguments():
     parser.add_argument('--niter', type=int, default=4, help='Omnifold iteration to load')
     parser.add_argument('--nmax', type=int, default=20_000_000, help='Maximum number of events to load')
     parser.add_argument('--verbose', action='store_true', default=False,help='Increase print level')
-    parser.add_argument('--save_zjet', action='store_true', default=False, help='Save zjet using all jets')
     flags = parser.parse_args()
 
     return flags
@@ -91,11 +90,11 @@ def main():
     undo_standardizing(flags,dataloaders)
     #num_part = dataloaders['Rapgap'].part.shape[1]
     
-    cluster_jets(dataloaders, store_all_jets = flags.save_zjet)
-    cluster_breit(dataloaders, clustering_algorithm="kt", store_all_jets = flags.save_zjet)
+    cluster_jets(dataloaders)
+    cluster_breit(dataloaders)
     del dataloaders[flags.file].part, dataloaders[flags.file].mask
     gc.collect()
-    gather_data(dataloaders, store_all_jets = flags.save_zjet)
+    gather_data(dataloaders)
 
     replace_string = f"unfolded_{flags.niter}_ryantest"
     if flags.reco:
@@ -116,9 +115,8 @@ def main():
             dset = fh5.create_dataset('jet_breit_pt', data=dataloaders[flags.file].jet_breit[:,0])
             dset = fh5.create_dataset('deltaphi', data=get_deltaphi(dataloaders[flags.file].jet, dataloaders[flags.file].event))
             dset = fh5.create_dataset('jet_tau10', data=dataloaders[flags.file].jet[:,4])
-            if flags.save_zjet:
-                dset = fh5.create_dataset('zjet', data=dataloaders[flags.file].all_jets[:, :, 9])
-                dset = fh5.create_dataset('zjet_breit', data=dataloaders[flags.file].all_jets_breit[:, :, 7])
+            dset = fh5.create_dataset('zjet', data=dataloaders[flags.file].all_jets[:, :, 9])
+            dset = fh5.create_dataset('zjet_breit', data=dataloaders[flags.file].all_jets_breit[:, :, 7])
     
 if __name__ == '__main__':
     main()

--- a/scripts/save_unfolded.py
+++ b/scripts/save_unfolded.py
@@ -96,7 +96,7 @@ def main():
     gc.collect()
     gather_data(dataloaders)
 
-    replace_string = f"unfolded_{flags.niter}_ryantest"
+    replace_string = f"unfolded_{flags.niter}"
     if flags.reco:
         replace_string += '_reco'
     output_file_name = flags.file.replace("prep",replace_string)

--- a/scripts/save_unfolded.py
+++ b/scripts/save_unfolded.py
@@ -31,7 +31,7 @@ def parse_arguments():
     parser.add_argument('--niter', type=int, default=4, help='Omnifold iteration to load')
     parser.add_argument('--nmax', type=int, default=20_000_000, help='Maximum number of events to load')
     parser.add_argument('--verbose', action='store_true', default=False,help='Increase print level')
-    
+    parser.add_argument('--save_zjet', action='store_true', default=False, help='Save zjet using all jets')
     flags = parser.parse_args()
 
     return flags
@@ -86,12 +86,13 @@ def main():
     undo_standardizing(flags,dataloaders)
     #num_part = dataloaders['Rapgap'].part.shape[1]
     
-    cluster_breit(dataloaders)
-    cluster_jets(dataloaders)
+    cluster_jets(dataloaders, store_all_jets = flags.save_zjet)
+    cluster_breit(dataloaders, clustering_algorithm="kt", store_all_jets = flags.save_zjet)
     del dataloaders[flags.file].part, dataloaders[flags.file].mask
     gc.collect()
-    gather_data(dataloaders)
-    replace_string = f"unfolded_{flags.niter}"
+    gather_data(dataloaders, store_all_jets = flags.save_zjet)
+
+    replace_string = f"unfolded_{flags.niter}_ryantest"
     if flags.reco:
         replace_string += '_reco'
     output_file_name = flags.file.replace("prep",replace_string)
@@ -105,7 +106,9 @@ def main():
             dset = fh5.create_dataset('jet_breit_pt', data=dataloaders[flags.file].jet_breit[:,0])
             dset = fh5.create_dataset('deltaphi', data=get_deltaphi(dataloaders[flags.file].jet, dataloaders[flags.file].event))
             dset = fh5.create_dataset('jet_tau10', data=dataloaders[flags.file].jet[:,4])
-
+            if flags.save_zjet:
+                dset = fh5.create_dataset('zjet', data=dataloaders[flags.file].all_jets[:, :, 9])
+                dset = fh5.create_dataset('zjet_breit', data=dataloaders[flags.file].all_jets_breit[:, :, 7])
             if 'closure' in weights:
                 dset = fh5.create_dataset('closure_weights', data=weights['closure'])
 

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -64,13 +64,17 @@ observable_names = {
     'jet_breit_pt': r'Breit frame Jet $p_{T}$ [GeV]',
     'deltaphi':r"$\Delta\phi^{jet}$ [rad]",
     'jet_tau10':r'$\mathrm{ln}(\lambda_1^1)$',
+    'zjet':r'Lab frame $z_{jet}$',
+    'zjet_breit':r'Breit frame $z_{jet}$'
 }
 
 dedicated_binning = {
     'jet_pt': np.logspace(np.log10(10),np.log10(100),7),
     'jet_breit_pt': np.logspace(np.log10(10),np.log10(50),7),
     'deltaphi': np.linspace(0, 1, 8),
-    'jet_tau10': np.array([-4.00,-3.15,-2.59,-2.18,-1.86,-1.58,-1.29,-1.05,-0.81,-0.61,0.00])
+    'jet_tau10': np.array([-4.00,-3.15,-2.59,-2.18,-1.86,-1.58,-1.29,-1.05,-0.81,-0.61,0.00]),
+    'zjet' : np.linspace(0.2, 1, 10),
+    'zjet_breit' : np.linspace(0.2, 1, 10)
 }
 
 def get_log(var):
@@ -79,6 +83,8 @@ def get_log(var):
     if 'deltaphi' in var:
         return True, True
     if 'tau' in var:
+        return False, False
+    if 'zjet' in var:
         return False, False
     else:
         print(f"ERROR: {var} not present!")
@@ -91,6 +97,10 @@ def get_ylim(var):
         return 1e-3, 50
     if 'tau' in var:
         return 0, 1.2
+    if var == 'zjet':
+        return 0,5
+    if var == 'zjet_breit':
+        return 0,3
     else:
         print("ERROR")
 


### PR DESCRIPTION
Added the calculation of zjet in both the lab frame and Breit frame. This uses all the jets in each event, with a maximum of 5 jets per event. Plotting of zjet in both frames has also been added, as well as the possibility of plotting other multijet observables.