### PR TITLE
Plot update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+plots/
+__pycache__/

--- a/scripts/options.py
+++ b/scripts/options.py
@@ -165,7 +165,7 @@ name_translate = {
     'Rapgap_unfolded': 'RAPGAP + Unfolding',
     'Rapgap_closure': 'RAPGAP Closure',
     'Djangoh': 'DJANGOH',
-    'data': 'Data',
+    'data': 'Data (Omnifold)',
     'Data_unfolded': 'Data Unfolded'
 
 }

--- a/scripts/plot_from_file.py
+++ b/scripts/plot_from_file.py
@@ -12,26 +12,28 @@ import h5py as h5
 
 utils.SetStyle()
 
-# var_names = ['weights','mc_weights','jet_pt',
-            #  'jet_breit_pt','deltaphi','jet_tau10', 'zjet', 'zjet_breit']
-var_names = ['jet_pt']
+var_names = ['weights','mc_weights','jet_pt',
+             'jet_breit_pt','deltaphi','jet_tau10', 'zjet', 'zjet_breit']
+# var_names = ['jet_breit_pt']
 
 def get_sample_names(niter, use_sys, sys_list = ['sys0','sys1','sys5','sys7','sys11'],
-                     nominal = 'Rapgap',period = 'Eplus0607',reco=False,bootstrap=False,nboot=1):
-    add_string = '_prelimnote_reco' if reco else ''
+                     nominal = 'Rapgap',period = 'Eplus0607',reco=False,bootstrap=False,nboot=1,prelim=False):
+    add_string = '_reco' if reco else ''
+    prelim_string = '_prelimnote' if prelim else ''
+
     mc_file_names = {
-        'Rapgap':f'Rapgap_{period}_unfolded_{niter}{add_string}.h5',
-        'Djangoh':f'Djangoh_{period}_unfolded_{niter}{add_string}.h5',
+        'Rapgap':f'Rapgap_{period}_unfolded_{niter}{prelim_string}{add_string}.h5',
+        'Djangoh':f'Djangoh_{period}_unfolded_{niter}{prelim_string}{add_string}.h5',
     }
     if reco:
-        mc_file_names['data'] = f'data_{period}_unfolded_{niter}{add_string}.h5'
+        mc_file_names['data'] = f'data_{period}_unfolded_{niter}{prelim_string}{add_string}.h5'
 
     if use_sys:
         for sys in sys_list:
-            mc_file_names[f'{sys}'] = f'{nominal}_{period}_{sys}_unfolded_{niter}{add_string}.h5'
+            mc_file_names[f'{sys}'] = f'{nominal}_{period}_{sys}_unfolded_{niter}{prelim_string}{add_string}.h5'
 
     if bootstrap:
-        mc_file_names['bootstrap'] = f'{nominal}_{period}_unfolded_{niter}_boot.h5'
+        mc_file_names['bootstrap'] = f'{nominal}_{period}_unfolded_{niter}{prelim_string}_boot.h5'
             
     return mc_file_names
 
@@ -51,6 +53,7 @@ def parse_arguments():
     parser.add_argument('--niter', type=int, default=4, help='Omnifold iteration to load')
     parser.add_argument('--bootstrap', action='store_true', default=False,help='Load models for bootstrapping')
     parser.add_argument('--nboot', type=int, default=50, help='Number of bootstrap models to load')
+    parser.add_argument('--prelim', action='store_true', default=False,help='Load files with prelimnote label')
 
     parser.add_argument('--verbose', action='store_true', default=False,help='Increase print level')
     
@@ -79,7 +82,7 @@ def main():
     flags = parse_arguments()
     opt=utils.LoadJson(flags.config)
     mc_files = get_sample_names(niter=flags.niter,use_sys=flags.sys,
-                                reco=flags.reco,bootstrap=flags.bootstrap,nboot=flags.nboot)
+                                reco=flags.reco,bootstrap=flags.bootstrap,nboot=flags.nboot,prelim=flags.prelim)
     if flags.verbose:
         print(f'Will load the following files : {mc_files.keys()}')
         

--- a/scripts/plot_from_file.py
+++ b/scripts/plot_from_file.py
@@ -12,13 +12,13 @@ import h5py as h5
 
 utils.SetStyle()
 
-var_names = ['weights','mc_weights','jet_pt',
-             'jet_breit_pt','deltaphi','jet_tau10', 'zjet', 'zjet_breit']
-
+# var_names = ['weights','mc_weights','jet_pt',
+            #  'jet_breit_pt','deltaphi','jet_tau10', 'zjet', 'zjet_breit']
+var_names = ['jet_pt']
 
 def get_sample_names(niter, use_sys, sys_list = ['sys0','sys1','sys5','sys7','sys11'],
                      nominal = 'Rapgap',period = 'Eplus0607',reco=False,bootstrap=False,nboot=1):
-    add_string = '_reco' if reco else ''
+    add_string = '_prelimnote_reco' if reco else ''
     mc_file_names = {
         'Rapgap':f'Rapgap_{period}_unfolded_{niter}{add_string}.h5',
         'Djangoh':f'Djangoh_{period}_unfolded_{niter}{add_string}.h5',

--- a/scripts/plot_utils.py
+++ b/scripts/plot_utils.py
@@ -384,6 +384,7 @@ def plot_qtQ(flags,dataloaders,data_weights,version):
                                reference_name = reference_name,
                                label_loc='upper left',
                                )
+    ax.set_ylim(1e-2,50)
     fig.savefig('../plots/{}_jet_pt.pdf'.format(version))
 
     feed_dict = {
@@ -608,7 +609,7 @@ def plot_jet_pt(flags, dataloaders, data_weights, version,lab_frame=True):
     )
 
     # Set plot limits and save
-    #ax.set_ylim(1e-2, 50)
+    # ax.set_ylim(1e-2, 50)
     tag = 'lab' if lab_frame else 'breit'
     
     fig.savefig(f'../plots/{version}_jet_pt_{tag}.pdf')

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -92,11 +92,12 @@ def get_log(var):
 
 def get_ylim(var):
     if var == "jet_pt":
-        return 1e-5, 1
+        # return 1e-5, 1
+        return 1e-5, 5
     if var == "jet_breit_pt":
-        return 1e-4, 1
+        return 1e-4, 4
     if 'deltaphi' in var:
-        return 1e-3, 50
+        return 1e-3, 120
     if 'tau' in var:
         return 0, 1.2
     if var == 'zjet':
@@ -177,7 +178,8 @@ def SetStyle():
 #     return fig,gs
 
 def SetGrid(ratio=True):
-    fig = plt.figure(figsize=(9, 9))
+    # fig = plt.figure(figsize=(9, 9))
+    fig = plt.figure(figsize=(12, 12))
     if ratio:
         gs = gridspec.GridSpec(2, 1, height_ratios=[3,1]) 
         gs.update(wspace=0.025, hspace=0.1)
@@ -187,7 +189,7 @@ def SetGrid(ratio=True):
 
 
 
-def FormatFig(xlabel,ylabel,ax0,xpos=0.83,ypos=1.035):
+def FormatFig(xlabel,ylabel,ax0,xpos=0.8,ypos=0.95):
     #Limit number of digits in ticks
     # y_loc, _ = plt.yticks()
     # y_update = ['%.1f' % y for y in y_loc]
@@ -197,16 +199,32 @@ def FormatFig(xlabel,ylabel,ax0,xpos=0.83,ypos=1.035):
         
 
     text = r'$\bf{H1 Preliminary}$'
-    WriteText(xpos,ypos,text,ax0)
+    WriteText(xpos,ypos,text,ax0, align='left')
 
+    second_text = r'$\mathrm{Unfolded\ single\ particle\ dataset}$'
+    WriteText(xpos, ypos-0.06, second_text, ax0, fontsize=18, align='left')
 
-def WriteText(xpos,ypos,text,ax0):
+    phasespace_text = r'$Q^2>150~\mathrm{GeV}^2, 0.2<y<0.7$'
+
+    if "Breit frame" in xlabel.strip():
+        frame_text = "Breit Frame"
+        phasespace_text += "\n" + r'$p_T^{jet} > 5 GeV$'
+    else: 
+        frame_text = "Lab Frame"
+        phasespace_text += "\n" + r'$p_T^{jet} > 10 GeV\ k_{T}, R = 1.0$'
+
+    WriteText(xpos, ypos-0.15, frame_text, ax0, fontsize=18, align='left')
+    WriteText(xpos, ypos-0.25, phasespace_text, ax0, fontsize=18, align='left')
+
+    
+
+def WriteText(xpos,ypos,text,ax0, fontsize=25, align='center'):
 
     plt.text(xpos, ypos,text,
              horizontalalignment='center',
              verticalalignment='center',
              #fontweight='bold',
-             transform = ax0.transAxes, fontsize=25)
+             transform = ax0.transAxes, fontsize=fontsize)
 
 
 def LoadJson(file_name,base_path='../JSON'):
@@ -283,6 +301,7 @@ def HistRoutine(feed_dict,
     """
     Generate a histogram plot with optional ratio and uncertainties.
     """
+
     import numpy as np
     import matplotlib.pyplot as plt
     from utils import SetGrid, FormatFig
@@ -291,8 +310,8 @@ def HistRoutine(feed_dict,
 
     # Default styles for plots
     ref_plot_style = {'histtype': 'stepfilled', 'alpha': 0.2}
-    other_plot_style = {'histtype': 'step', 'linewidth': 2}
-    marker_style = {'marker': 'o', 'linestyle': 'None', 'markersize': 8, 'color': 'black', 'label': 'Data'}
+    other_plot_style = {'histtype': 'step', 'linewidth': 3}
+    marker_style = {'marker': 'o', 'linestyle': 'None', 'markersize': 8, 'color': 'black', 'label': 'Data (Omnifold)'}
 
     # Set up the figure and axes
     fig, gs = SetGrid(ratio=plot_ratio)
@@ -317,7 +336,8 @@ def HistRoutine(feed_dict,
     reference_hist, _ = np.histogram(feed_dict[reference_name], bins=binning, density=True, weights=ref_weights)
 
     max_y = 0
-
+    data_hist_values = None
+    data_y_errors = None
     # Plot each distribution
     for plot_name, data in feed_dict.items():
         plot_weights = weights[plot_name] if weights else None
@@ -332,9 +352,10 @@ def HistRoutine(feed_dict,
             nonzero = bin_counts > 0
             y_errors = np.asarray(y_errors)  # Ensure y_errors is a NumPy array
             y_errors[nonzero] = hist_values[nonzero] / np.sqrt(bin_counts[nonzero])  # Poisson errors
-            print(f"hist_values: {hist_values}")
-            print(f"y_errors: {y_errors}")
             ax0.errorbar(bin_centers, hist_values, yerr=y_errors, **marker_style)
+
+            data_hist_values = hist_values
+            data_y_errors = y_errors
 
             max_y = max(max_y, np.max(hist_values))
 
@@ -353,27 +374,80 @@ def HistRoutine(feed_dict,
             # Plot ratio if applicable
             if plot_ratio and plot_name != reference_name:
                 ratio = np.ma.divide(dist, reference_hist).filled(0)
-                ax1.plot(
-                    xaxis, ratio,
-                    color=options.colors[plot_name],
-                    marker=options.markers[plot_name],
-                    ms=10, lw=0,
-                    markerfacecolor='none', markeredgewidth=3
-                )
-
-                # Add uncertainties
+                
+                # For logarithmic binning
+                if logx:
+                    # Calculate the bin edges for proper extension in log space
+                    bin_edges = np.zeros(len(binning))
+                    for i in range(len(binning)):
+                        bin_edges[i] = binning[i]
+                    
+                    # Create extended ratio array for steps-post style
+                    extended_ratio = np.zeros(len(bin_edges))
+                    for i in range(len(ratio)):
+                        extended_ratio[i] = ratio[i]
+                    
+                    ax1.plot(
+                        bin_edges, extended_ratio,
+                        color=options.colors[plot_name],
+                        drawstyle='steps-post',
+                        linestyle='-',
+                        lw=3,
+                        ms=10,
+                        markerfacecolor='none', markeredgewidth=3
+                    )
+                else:
+                    # For linear binning
+                    bin_width = binning[1] - binning[0]
+                    extended_xaxis = np.append(xaxis, xaxis[-1] + bin_width)
+                    extended_ratio = np.append(ratio, ratio[-1])
+                    
+                    ax1.plot(
+                        extended_xaxis, extended_ratio,
+                        color=options.colors[plot_name],
+                        drawstyle='steps-post',
+                        linestyle='-',
+                        lw=3,
+                        ms=10,
+                        markerfacecolor='none', markeredgewidth=3
+                    )
+                
                 if uncertainty is not None:
                     for ibin in range(len(binning)-1):
                         xup = binning[ibin+1]
                         xlow = binning[ibin]
                         ax1.fill_between(np.array([xlow,xup]),
                                          1.0 + uncertainty[ibin],1.0 -uncertainty[ibin],
-                                         alpha=0.3,color='k')
+                                         alpha=0.1,color='k')
+                        # Overlay hatch using bar
+                        ax1.bar((xlow + xup) / 2, 2 * uncertainty[ibin], width=(xup - xlow), 
+                                bottom=1.0 - uncertainty[ibin], hatch='//', color='none', edgecolor='grey')
+
+    # Add data points at 1.0 in the ratio plot with error bars
+    if plot_ratio and data_hist_values is not None and data_y_errors is not None:
+        # Calculate relative errors for the ratio plot
+        relative_errors = data_y_errors / data_hist_values
+        # Filter out NaN or inf values
+        valid_indices = ~np.isnan(relative_errors) & ~np.isinf(relative_errors) & (data_hist_values > 0)
+        
+        # Plot data points at 1.0 with relative error bars
+        ax1.errorbar(
+            xaxis[valid_indices], 
+            np.ones_like(xaxis)[valid_indices],  # y-value of 1.0
+            yerr=data_y_errors[valid_indices],
+            marker='o', 
+            linestyle='None', 
+            markersize=8, 
+            color='black',
+            capsize=3
+        )
 
     # Adjust y-axis scale
     if logy:
         ax0.set_yscale('log')
-        ax0.set_ylim(1e-5, 10 * max_y)
+        # ax0.set_ylim(1e-5, 10 * max_y)
+        ax0.set_ylim(1e-5, 10000 * max_y)
+
     else:
         ax0.set_ylim(0, 1.3 * max_y)
 
@@ -384,9 +458,11 @@ def HistRoutine(feed_dict,
             ax1.set_xscale('log')
 
     # Add legend and format axes
-    ax0.legend(loc=label_loc, fontsize=16, ncol=2)
+    # ax0.legend(loc=label_loc, fontsize=16, ncol=2)
+    ax0.legend(loc=label_loc, fontsize=20, ncol=1)
+
     if plot_ratio:
-        FormatFig(xlabel="", ylabel=ylabel, ax0=ax0)
+        FormatFig(xlabel=xlabel, ylabel=ylabel, ax0=ax0)
         ax1.set_ylabel('Pred./Ref.')
         ax1.axhline(y=1.0, color='r', linestyle='-', linewidth=1)
         ax1.set_ylim([0.5, 1.5])


### PR DESCRIPTION
Plot style changes according to Stefan's suggestions

- Added flag "--prelim" to plot_from_file.py, which will consider input files with "prelim" string
- Change "Data" to "Data (Omnifold)" for reco level plots
- "H1 Preliminary" is now inside the canvas with additional descriptive text "Unfolded single particle dataset"
- Added "Breit" or "Lab" frame text inside canvas, depending on the variable name
- Added phase space selection
- Data now displayed as points with stat errors on top and bottom plots for the "reco" option
- Uncertainties in the bottom plot drawn as a shaded area
- MC shown as lines in the bottom plot
- 1 column legend with bigger font

Note: will squash once i get 👍 