### PR TITLE
Memory efficient batching to read unfolded weights and make plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,83 @@ After the unfolding is done, you can run the evaluation code to load the trained
 python evaluate.py [--dataset ep/em] [--niter I] [--load_pretrain] [--file Rapgap] [--bootstrap]
 
 
-## Plotting
+## Saving unfolded weights to batch files
+
+`save_unfolded_weights.py` reads a pre-evaluated weights file (produced by `evaluate.py`), clusters jets, computes observables, and writes the results to per-batch HDF5 files. Each MPI rank processes one independent batch of events in parallel, so the script scales to large datasets without loading everything into memory at once.
+
+Each output file is named:
+```
+<base>_unfolded_<niter>[_reco][_boot]_batch<NNNN>.h5
+```
+and contains datasets: `jet_pt`, `jet_breit_pt`, `deltaphi`, `jet_tau10`, `zjet`, `zjet_breit`, plus `weights_nominal`, `weights<i>` (bootstrap), `mc_weights`, and `closure_weights` for MC files.
+
+Start by initiating an interactive SLURM session:
+```bash
+
+```
+salloc -C cpu -q interactive -t 240 -N 4 -A m3246 --image=vmikuni/tensorflow:ngc-23.12-tf2-v1 --cpus-per-task=64 --ntasks=16
+```bash
+srun --mpi=pmi2 shifter python save_unfolded_weights.py \
+    --niter 4 \
+    --load_pretrain \
+    --file Rapgap_Eplus0607_prep.h5 \
+    --nmax 18000000 \
+    --batch_size 30000 \
+    --data_folder /path/to/h5 \
+    --pre_weights_file Rapgap_Eplus0607_unfolded_niter_4.h5 \
+    --bootstrap \
+    --nboot 50
+```
+Key arguments:
+
+| Argument | Default | Description |
+|---|---|---|
+| `--data_folder` | `/pscratch/sd/v/vmikuni/H1v2/h5` | Folder containing input and output h5 files |
+| `--weights` | `../weights` | Folder with trained model weights |
+| `--file` | `Rapgap_Eplus0607_prep.h5` | Input MC (or data) file |
+| `--pre_weights_file` | `None` | HDF5 file with pre-evaluated unfolded weights from `evaluate.py` |
+| `--niter` | `4` | OmniFold iteration to load |
+| `--nmax` | `10000000` | Total number of events to process |
+| `--batch_size` | `30000` | Events per rank/batch |
+| `--bootstrap` | `False` | Save per-replica bootstrap weights |
+| `--nboot` | `50` | Number of bootstrap replicas |
+| `--reco` | `False` | Process reco-level events instead of gen-level |
+
+## Plotting from batch files
+
+`plot_from_batches.py` is a memory-efficient alternative to `plot.py`. Instead of loading all events at once, it iterates over the batch HDF5 files produced by `save_unfolded_weights.py` and accumulates weighted histograms for each observable.
+
+Systematics, closure, and bootstrap statistical uncertainties are computed in the same way as the standard plotting code.
+
+```bash
+python plot_from_batches.py \
+    --data_folder /path/to/h5 \
+    --period Eplus0607 \
+    --suffix boot \
+    --niter 4 \
+    --bootstrap \
+    --nboot 50 \
+    [--sys] [--reco] [--blind]
+```
+
+Key arguments:
+
+| Argument | Default | Description |
+|---|---|---|
+| `--data_folder` | `/pscratch/sd/v/vmikuni/H1v2/h5` | Folder containing the batch h5 files |
+| `--plot_folder` | `../plots` | Output directory for plots |
+| `--period` | `Eplus0607` | Data-taking period string used in file names |
+| `--suffix` | `boot` | Middle suffix in batch file names (e.g. `boot`) |
+| `--niter` | `4` | OmniFold iteration to load |
+| `--bootstrap` | `False` | Compute stat uncertainty from bootstrap replicas |
+| `--nboot` | `50` | Number of bootstrap replicas |
+| `--sys` | `False` | Load and propagate systematic variations |
+| `--reco` | `False` | Plot reco-level results |
+| `--blind` | `False` | Show closure results instead of data |
+
+Plots are saved as PDFs named `<version>_<period>_<var>_<tag>.pdf` where `tag` is `unfolded`, `reco`, or `closure`.
+
+<!-- ## Plotting
 
 Plotting can be performed using either multiple GPUs or in a single GPU. The script to run is:
 
@@ -98,4 +174,4 @@ salloc -C gpu -q interactive  -t 40 -n 16 --ntasks-per-node=4 --gpus-per-task=1 
 module load tensorflow
 [pip install --user fastjet] #Do it only once
 srun  python plot.py --niter 5 --closure --load_pretrain --data_folder /global/cfs/cdirs/m3246/H1/h5/ --weights /global/cfs/cdirs/m3246/H1/weights/
-```
+``` -->

--- a/README.md
+++ b/README.md
@@ -78,9 +78,8 @@ After the unfolding is done, you can run the evaluation code to load the trained
 
 ```bash
 python evaluate.py [--dataset ep/em] [--niter I] [--load_pretrain] [--file Rapgap] [--bootstrap]
-
-
-## Saving unfolded weights to batch files
+```
+### Saving unfolded weights to batch files
 
 `save_unfolded_weights.py` reads a pre-evaluated weights file (produced by `evaluate.py`), clusters jets, computes observables, and writes the results to per-batch HDF5 files. Each MPI rank processes one independent batch of events in parallel, so the script scales to large datasets without loading everything into memory at once.
 
@@ -92,9 +91,9 @@ and contains datasets: `jet_pt`, `jet_breit_pt`, `deltaphi`, `jet_tau10`, `zjet`
 
 Start by initiating an interactive SLURM session:
 ```bash
-
-```
 salloc -C cpu -q interactive -t 240 -N 4 -A m3246 --image=vmikuni/tensorflow:ngc-23.12-tf2-v1 --cpus-per-task=64 --ntasks=16
+```
+Then,
 ```bash
 srun --mpi=pmi2 shifter python save_unfolded_weights.py \
     --niter 4 \

--- a/scripts/cluster_h1_jets.py
+++ b/scripts/cluster_h1_jets.py
@@ -1,0 +1,261 @@
+"""
+Read H1 MC events from a ROOT file with pre-selected hadrons and scattered electron,
+cluster into jets using FastJet kt algorithm (R=1.0, pT > 7 GeV), compute jet
+observables, and save to a new ROOT file.
+
+Input tree branches:
+  weight, Q2, y, x,
+  elec_pt, elec_E, elec_eta, elec_phi,
+  nhadron, hadron_pt, hadron_E, hadron_eta, hadron_phi, hadron_charge
+"""
+
+import uproot
+import numpy as np
+import fastjet
+import awkward as ak
+import argparse
+
+PROTON_BEAM = np.array([0.0, 0.0, 920.0, 920.0])  # px, py, pz, E
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description="Cluster jets from H1 MC DIS events and compute observables."
+    )
+    parser.add_argument("--input", required=True, help="Path to input ROOT file")
+    parser.add_argument("--output", required=True, help="Path to output ROOT file")
+    parser.add_argument("--tree", default="Tree", help="Name of input TTree")
+    parser.add_argument("-R", type=float, default=1.0, help="Jet radius parameter")
+    parser.add_argument("--ptmin", type=float, default=7.0, help="Min jet pT (lab frame)")
+    parser.add_argument("--breit_ptmin", type=float, default=5.0, help="Min jet pT (Breit frame)")
+    parser.add_argument("--no_breit", action="store_true", default=False,
+                        help="Skip Breit-frame clustering (zjet_breit will be absent)")
+    parser.add_argument("--num_events", default=None, type=int,
+                        help="Number of events to process")
+    return parser.parse_args()
+
+
+def to_cartesian(pt, eta, phi, E=None):
+    """Convert (pt, eta, phi) to (px, py, pz). If E is None, assumes massless."""
+    px = pt * np.cos(phi)
+    py = pt * np.sin(phi)
+    pz = pt * np.sinh(eta)
+    if E is None:
+        E = np.sqrt(px**2 + py**2 + pz**2)
+    return px, py, pz, E
+
+
+def calculate_q(hfs_pz, hfs_energy, elec_px, elec_py, elec_pz, elec_E):
+    """Compute virtual photon 4-momentum q = k - k' via the sigma method."""
+    sigma_h = np.sum(hfs_energy - hfs_pz)
+    elec_p = np.sqrt(elec_px**2 + elec_py**2 + elec_pz**2)
+    elec_theta = np.arccos(np.clip(elec_pz / elec_p, -1, 1)) if elec_p > 0 else 0.0
+    sigma_eprime = elec_E * (1 - np.cos(elec_theta))
+    sigma_tot = sigma_h + sigma_eprime
+
+    beam_pz = -sigma_tot / 2.0
+    beam_E = sigma_tot / 2.0
+
+    q = np.array([0.0 - elec_px,
+                  0.0 - elec_py,
+                  beam_pz - elec_pz,
+                  beam_E  - elec_E])
+    return q
+
+
+def boost_particles_to_breit(px, py, pz, E, q):
+    """Vectorized Breit-frame boost (one event at a time)."""
+    qx, qy, qz, qE = q
+    qpt = np.sqrt(qx * qx + qy * qy)
+
+    qdotq = qE * qE - qx * qx - qy * qy - qz * qz
+    Q = np.sqrt(-qdotq)
+    Sigma = qE - qz
+
+    Q2_over_sigma = (Q * Q) / Sigma
+    boostvector_px = qx
+    boostvector_py = qy
+    boostvector_pz = qz + Q2_over_sigma
+    boostvector_E  = qE + Q2_over_sigma
+
+    xboost_px = qx / qpt
+    xboost_py = qy / qpt
+    xboost_pz = qpt / Sigma
+    xboost_E  = qpt / Sigma
+
+    yboost_px = -qy / qpt
+    yboost_py =  qx / qpt
+
+    boosted_px = xboost_E * E - xboost_px * px - xboost_py * py - xboost_pz * pz
+    boosted_py = -yboost_px * px - yboost_py * py
+    boosted_pz = (qE * E - qx * px - qy * py - qz * pz) / Q
+    boosted_E  = (boostvector_E * E - boostvector_px * px
+                  - boostvector_py * py - boostvector_pz * pz) / Q
+
+    return boosted_px, boosted_py, boosted_pz, boosted_E
+
+
+def calculate_breit_zjet(breit_jet, Q):
+    n = np.array([0, 0, 1, 1], dtype=np.float64)
+    numerator = n[3] * breit_jet.E() - n[2] * breit_jet.pz()
+    return numerator / Q
+
+
+def calculate_jet_features(jet, q, P_dot_q):
+    """Compute substructure observables for a single jet."""
+    tau_10 = 0.0
+    for constituent in jet.constituents():
+        dr = jet.delta_R(constituent)
+        pt = constituent.pt()
+        tau_10 += pt * dr
+
+    jet_pt = jet.pt()
+    log_tau_10 = np.log(tau_10 / jet_pt) if jet_pt > 0 and tau_10 > 0 else np.nan
+
+    P_dot_jet = (PROTON_BEAM[3] * jet.E()
+                 - PROTON_BEAM[0] * jet.px()
+                 - PROTON_BEAM[1] * jet.py()
+                 - PROTON_BEAM[2] * jet.pz())
+    zjet = P_dot_jet / P_dot_q if P_dot_q != 0 else np.nan
+
+    phi = (jet.phi() + np.pi) % (2 * np.pi) - np.pi
+    return jet_pt, phi, log_tau_10, zjet
+
+
+def make_pseudojets(px, py, pz, E):
+    return [fastjet.PseudoJet(float(px[i]), float(py[i]), float(pz[i]), float(E[i]))
+            for i in range(len(px))]
+
+
+def main():
+    flags = parse_arguments()
+    R = flags.R
+
+    print(f"Opening {flags.input}")
+    with uproot.open(flags.input) as f:
+        t = f[flags.tree]
+        branches = [
+            "weight", "Q2", "y", "x",
+            "elec_pt", "elec_E", "elec_eta", "elec_phi",
+            "hadron_pt", "hadron_E", "hadron_eta", "hadron_phi",
+        ]
+        data = t.arrays(branches, library="ak", entry_stop=flags.num_events)
+
+    n_events = len(data["Q2"])
+    print(f"Read {n_events} events")
+
+    jetdef = fastjet.JetDefinition(fastjet.kt_algorithm, R)
+
+    do_breit = not flags.no_breit
+
+    # Per-event output (jagged)
+    out_jet_pt    = []
+    out_jet_tau10 = []
+    out_zjet      = []
+    out_deltaphi  = []
+    out_njets     = []
+    if do_breit:
+        out_breit_pt   = []
+        out_zjet_breit = []
+
+    # Event-level kinematics (one per event, kept in sync with jet lists)
+    out_weight = []
+    out_Q2     = []
+    out_x      = []
+    out_y      = []
+
+    for i in range(n_events):
+        if i % 100_000 == 0:
+            print(f"  Event {i}/{n_events}")
+
+        Q2_i = float(data["Q2"][i])
+        x_i  = float(data["x"][i])
+        y_i  = float(data["y"][i])
+        w_i  = float(data["weight"][i])
+
+        # Scattered electron
+        elec_px, elec_py, elec_pz, elec_E = to_cartesian(
+            float(data["elec_pt"][i]),
+            float(data["elec_eta"][i]),
+            float(data["elec_phi"][i]),
+            float(data["elec_E"][i]),
+        )
+        elec_phi_val = float(data["elec_phi"][i])
+
+        # Hadrons
+        h_pt  = np.asarray(data["hadron_pt"][i],  dtype=np.float64)
+        h_E   = np.asarray(data["hadron_E"][i],   dtype=np.float64)
+        h_eta = np.asarray(data["hadron_eta"][i], dtype=np.float64)
+        h_phi = np.asarray(data["hadron_phi"][i], dtype=np.float64)
+
+        if len(h_pt) == 0:
+            out_jet_pt.append([]);    out_jet_tau10.append([])
+            out_zjet.append([]);      out_deltaphi.append([])
+            out_njets.append(0)
+            out_weight.append(w_i);  out_Q2.append(Q2_i)
+            out_x.append(x_i);       out_y.append(y_i)
+            if do_breit:
+                out_breit_pt.append([]); out_zjet_breit.append([])
+            continue
+
+        hfs_px, hfs_py, hfs_pz, hfs_E = to_cartesian(h_pt, h_eta, h_phi, h_E)
+
+        q = calculate_q(hfs_pz, hfs_E, elec_px, elec_py, elec_pz, elec_E)
+        P_dot_q = PROTON_BEAM[3] * q[3] - PROTON_BEAM[2] * q[2]
+
+        lab_pseudojets = make_pseudojets(hfs_px, hfs_py, hfs_pz, hfs_E)
+        lab_cluster = fastjet.ClusterSequence(lab_pseudojets, jetdef)
+        lab_jets = fastjet.sorted_by_pt(lab_cluster.inclusive_jets(ptmin=flags.ptmin))
+
+        ev_pt = []; ev_tau10 = []; ev_zjet = []; ev_dphi = []
+        for jet in lab_jets:
+            jpt, jphi, ltau, zj = calculate_jet_features(jet, q, P_dot_q)
+            delta_phi = np.abs(np.pi + jphi - elec_phi_val) % (2 * np.pi)
+            ev_pt.append(jpt);    ev_tau10.append(ltau)
+            ev_zjet.append(zj);   ev_dphi.append(delta_phi)
+
+        out_jet_pt.append(ev_pt);    out_jet_tau10.append(ev_tau10)
+        out_zjet.append(ev_zjet);    out_deltaphi.append(ev_dphi)
+        out_njets.append(len(ev_pt))
+        out_weight.append(w_i);  out_Q2.append(Q2_i)
+        out_x.append(x_i);       out_y.append(y_i)
+
+        if do_breit:
+            breit_px, breit_py, breit_pz, breit_E = boost_particles_to_breit(
+                hfs_px, hfs_py, hfs_pz, hfs_E, q)
+            pseudojets_breit = make_pseudojets(breit_px, breit_py, breit_pz, breit_E)
+            breit_cluster = fastjet.ClusterSequence(pseudojets_breit, jetdef)
+            breit_jets = fastjet.sorted_by_pt(
+                breit_cluster.inclusive_jets(ptmin=flags.breit_ptmin))
+            ev_bpt = [np.sqrt(j.px()**2 + j.py()**2) for j in breit_jets]
+            ev_bzjet = [calculate_breit_zjet(j, np.sqrt(Q2_i)) for j in breit_jets]
+            out_breit_pt.append(ev_bpt)
+            out_zjet_breit.append(ev_bzjet)
+
+    print(f"Writing output to {flags.output}")
+    event_tree = {
+        "weight": np.array(out_weight, dtype=np.float32),
+        "Q2":     np.array(out_Q2,     dtype=np.float32),
+        "x":      np.array(out_x,      dtype=np.float32),
+        "y":      np.array(out_y,      dtype=np.float32),
+        "njets":  np.array(out_njets,  dtype=np.int32),
+    }
+    jet_tree = {
+        "jet_pt":    out_jet_pt,
+        "jet_tau10": out_jet_tau10,
+        "zjet":      out_zjet,
+        "deltaphi":  out_deltaphi,
+    }
+    if do_breit:
+        jet_tree["jet_breit_pt"] = out_breit_pt
+        jet_tree["zjet_breit"]   = out_zjet_breit
+
+    with uproot.recreate(flags.output) as fout:
+        fout["events"] = event_tree
+        fout["jets"]   = jet_tree
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dataloader.py
+++ b/scripts/dataloader.py
@@ -19,6 +19,7 @@ class Dataset:
         pass_reco=False,
         preprocess=True,
         global_start=0,
+        global_end=0,
     ):
         self.rank = rank
         self.size = size
@@ -26,6 +27,7 @@ class Dataset:
         self.is_mc = is_mc
         self.nmax = nmax
         self.global_start = global_start
+        self.global_end = global_end
         self.preprocess = preprocess
 
         # Preprocessing parameters
@@ -53,8 +55,7 @@ class Dataset:
         self.std_event = [0.97656405, 0.1895471, 0.14934653, 0.4191545, 1.734126]
 
         self.prepare_dataset(file_names, pass_fiducial, pass_reco)
-        batch_events = self.nmax - self.global_start
-        self.normalize_weights(batch_events if norm is None else norm)
+        self.normalize_weights(self.nmax if norm is None else norm)
 
     def normalize_weights(self, norm):
         # print("Total number of reco events {}".format(self.num_pass_reco))
@@ -117,10 +118,10 @@ class Dataset:
             )
             del reco_e_batch
 
-            batch_events = self.nmax - self.global_start
+            batch_events = self.global_end - self.global_start
             per_rank = (batch_events + self.size - 1) // self.size  # ceiling division
             start = self.global_start + self.rank * per_rank
-            end = min(start + per_rank, self.nmax)
+            end = min(start + per_rank, self.global_end)
 
             reco_p = h5.File(os.path.join(self.base_path, f), "r")[
                 "reco_particle_features"

--- a/scripts/dataloader.py
+++ b/scripts/dataloader.py
@@ -108,10 +108,10 @@ class Dataset:
                     "reco_event_features"
                 ].shape[0]
 
-            # Sum of weighted events for collisions passing the reco cuts (within batch window)
+            # Sum of weighted events for collisions passing the reco cuts (full dataset up to nmax)
             reco_e_batch = h5.File(os.path.join(self.base_path, f), "r")[
                 "reco_event_features"
-            ][self.global_start : self.nmax]
+            ][: self.nmax]
             self.num_pass_reco += np.sum(
                 reco_e_batch[:, -2][reco_e_batch[:, -1] == 1]
             )

--- a/scripts/dataloader.py
+++ b/scripts/dataloader.py
@@ -18,12 +18,14 @@ class Dataset:
         pass_fiducial=False,
         pass_reco=False,
         preprocess=True,
+        global_start=0,
     ):
         self.rank = rank
         self.size = size
         self.base_path = base_path
         self.is_mc = is_mc
         self.nmax = nmax
+        self.global_start = global_start
         self.preprocess = preprocess
 
         # Preprocessing parameters
@@ -51,7 +53,8 @@ class Dataset:
         self.std_event = [0.97656405, 0.1895471, 0.14934653, 0.4191545, 1.734126]
 
         self.prepare_dataset(file_names, pass_fiducial, pass_reco)
-        self.normalize_weights(self.nmax if norm is None else norm)
+        batch_events = self.nmax - self.global_start
+        self.normalize_weights(batch_events if norm is None else norm)
 
     def normalize_weights(self, norm):
         # print("Total number of reco events {}".format(self.num_pass_reco))
@@ -105,20 +108,18 @@ class Dataset:
                     "reco_event_features"
                 ].shape[0]
 
-            # Sum of weighted events for collisions passing the reco cuts
+            # Sum of weighted events for collisions passing the reco cuts (within batch window)
+            reco_e_batch = h5.File(os.path.join(self.base_path, f), "r")[
+                "reco_event_features"
+            ][self.global_start : self.nmax]
             self.num_pass_reco += np.sum(
-                h5.File(os.path.join(self.base_path, f), "r")["reco_event_features"][
-                    : self.nmax, -2
-                ][
-                    h5.File(os.path.join(self.base_path, f), "r")[
-                        "reco_event_features"
-                    ][: self.nmax, -1]
-                    == 1
-                ]
+                reco_e_batch[:, -2][reco_e_batch[:, -1] == 1]
             )
+            del reco_e_batch
 
-            per_rank = (self.nmax + self.size - 1) // self.size  # ceiling division
-            start = self.rank * per_rank
+            batch_events = self.nmax - self.global_start
+            per_rank = (batch_events + self.size - 1) // self.size  # ceiling division
+            start = self.global_start + self.rank * per_rank
             end = min(start + per_rank, self.nmax)
 
             reco_p = h5.File(os.path.join(self.base_path, f), "r")[

--- a/scripts/plot_from_batches.py
+++ b/scripts/plot_from_batches.py
@@ -1,14 +1,22 @@
 """
 plot_from_batches.py
 
-Loads Rapgap and Djangoh batch h5 files one at a time and accumulates weighted
-histograms to avoid holding all events in memory simultaneously.
+Memory-efficient version of plot_part_from_file.py for EEC observables.
+Instead of loading all events at once, it reads multiple batch h5 files
+(e.g. Rapgap_Eplus0607_unfolded_4_centauro_boot_batch0000.h5, batch0001.h5, ...)
+and accumulates weighted histograms across them.
 
-Expected h5 keys per batch file:
-  jet_pt, jet_breit_pt, deltaphi, jet_tau10, zjet, zjet_breit  -- shape (n_events, n_jets)
-  mc_weights                                                     -- shape (n_events,)
-  weights_nominal                                                -- shape (n_events,)  [nominal unfolded]
-  weights1 .. weightsN                                           -- shape (n_events,)  [bootstrap]
+Systematics are calculated and applied exactly as in plot_part_from_file.py
+(plot_part_observable in plot_utils.py):
+  - nominal         = Rapgap   mc_weights * weights        (density)
+  - nominal_closure = Djangoh  mc_weights only             (density)
+  - For 'Rapgap' sys source : closure_weights, reference = nominal_closure
+  - For all other sys sources: weights,        reference = nominal
+  - Per-source uncertainty: (sys_hist / ref_hist - 1)^2
+  - Bootstrap stat uncertainty: std / mean over bootstrap replicas
+  - total_unc = sqrt( sum of squared uncertainties )
+
+Plot style uses utils.HistRoutinePart (same as plot_part_from_file.py).
 """
 
 import argparse
@@ -18,9 +26,6 @@ import gc
 
 import numpy as np
 import h5py as h5
-import matplotlib.pyplot as plt
-from matplotlib import gridspec
-from matplotlib.patches import Patch
 
 import utils
 import options
@@ -28,244 +33,105 @@ from utils import ObservableInfo
 
 utils.SetStyle()
 
-VAR_NAMES = [
-    "jet_pt",
-    "jet_breit_pt",
-    "deltaphi",
-    "jet_tau10",
-    "zjet",
-    "zjet_breit",
-]
-
-SYS_LIST_DEFAULT = ["sys0", "sys1", "sys5", "sys7", "sys11"]
+var_names = ['deltaphi', 'jet_pt', 'jet_tau10', 'zjet', 'zjet_breit']#, 'eec', 'theta']
 
 
 # ---------------------------------------------------------------------------
-# CLI
+# Batch file discovery
+# ---------------------------------------------------------------------------
+
+def get_batch_files(data_folder, period, niter, suffix,
+                    use_sys, sys_list=None, nominal='Rapgap',
+                    reco=False):
+    """
+    Return a dict mapping dataset label -> sorted list of batch h5 file paths.
+
+    File naming convention (example):
+      Rapgap_Eplus0607_unfolded_4_centauro_boot_batch0000.h5
+      Rapgap_Eplus0607_sys0_unfolded_4_centauro_boot_batch0000.h5
+      Djangoh_Eplus0607_unfolded_4_centauro_boot_batch0000.h5
+      data_Eplus0607_unfolded_4_centauro_reco_batch0000.h5  (reco mode, data only)
+    """
+    if sys_list is None:
+        sys_list = ['sys0', 'sys1', 'sys5', 'sys7', 'sys11']
+
+    mc_suffix = suffix.replace('_boot', '_reco_boot') if reco else suffix
+
+    def _glob(base_name):
+        pattern = os.path.join(
+            data_folder,
+            f'{base_name}_unfolded_{niter}_{mc_suffix}_batch*.h5'
+        )
+        files = sorted(glob.glob(pattern))
+        return files
+
+    batch_files = {
+        'Rapgap':  _glob(f'Rapgap_{period}'),
+        'Djangoh': _glob(f'Djangoh_{period}'),
+    }
+
+    if reco:
+        reco_data_suffix = suffix.replace('_boot', '') + '_reco'
+        data_pattern = os.path.join(
+            data_folder,
+            f'data_{period}_unfolded_{niter}_{reco_data_suffix}_batch*.h5'
+        )
+        batch_files['data'] = sorted(glob.glob(data_pattern))
+
+    if use_sys:
+        for sys in sys_list:
+            batch_files[sys] = _glob(f'{nominal}_{period}_{sys}')
+
+    return batch_files
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
 # ---------------------------------------------------------------------------
 
 def parse_arguments():
     parser = argparse.ArgumentParser(
-        description="Plot unfolded observables from batch h5 files without loading all data at once."
+        description='Memory-efficient EEC plot from batch h5 files.'
     )
-    parser.add_argument(
-        "--data_folder",
-        default="/global/cfs/cdirs/m3246/H1/h5",
-        help="Directory containing the batch h5 files",
-    )
-    parser.add_argument(
-        "--plot_folder",
-        default="../plots",
-        help="Directory to write output PDF plots",
-    )
-    parser.add_argument(
-        "--niter", type=int, default=4, help="OmniFold iteration used in file names"
-    )
-    parser.add_argument(
-        "--period", default="Eplus0607", help="Data-taking period string in file names"
-    )
-    parser.add_argument(
-        "--nboot",
-        type=int,
-        default=49,
-        help="Number of bootstrap weight sets (weights1..weightsN) to use for stat uncertainty",
-    )
-    parser.add_argument(
-        "--nominal_weight",
-        default="weights_nominal",
-        help="Key to use as the nominal unfolded weight (default: weights_nominal)",
-    )
-    parser.add_argument(
-        "--sys",
-        action="store_true",
-        default=False,
-        help="Load systematic variation batch files and compute systematic uncertainties",
-    )
-    parser.add_argument(
-        "--sys_list",
-        nargs="+",
-        default=SYS_LIST_DEFAULT,
-        help="List of systematic labels to include (default: sys0 sys1 sys5 sys7 sys11)",
-    )
-    parser.add_argument(
-        "--blind",
-        action="store_true",
-        default=False,
-        help="Closure mode: plot closure_weights result vs RAPGAP truth instead of data",
-    )
-    parser.add_argument(
-        "--verbose", action="store_true", default=False
-    )
-    return parser.parse_args()
+    parser.add_argument('--data_folder', default='/pscratch/sd/v/vmikuni/H1v2/h5',
+                        help='Folder containing the batch h5 files')
+    parser.add_argument('--config', default='config_general.json',
+                        help='Basic config file containing general options')
+    parser.add_argument('--plot_folder', default='../plots',
+                        help='Folder to store plots')
+    parser.add_argument('--period', default='Eplus0607',
+                        help='Data-taking period string in file names')
+    parser.add_argument('--suffix', default='centauro_boot',
+                        help='Middle suffix in batch file names (e.g. centauro_boot)')
+    parser.add_argument('--reco', action='store_true', default=False,
+                        help='Plot reco level results')
+    parser.add_argument('--sys', action='store_true', default=False,
+                        help='Load systematic variations')
+    parser.add_argument('--blind', action='store_true', default=False,
+                        help='Show results based on closure instead of data')
+    parser.add_argument('--niter', type=int, default=4,
+                        help='OmniFold iteration to load')
+    parser.add_argument('--bootstrap', action='store_true', default=False,
+                        help='Compute stat uncertainty from bootstrap replicas in batch files')
+    parser.add_argument('--nboot', type=int, default=50,
+                        help='Number of bootstrap replicas (weights1..weightsN) in the files')
+    parser.add_argument('--eec', action='store_true', default=False,
+                        help='Use eec mask and E_wgt (EEC mode)')
+    parser.add_argument('--verbose', action='store_true', default=False,
+                        help='Increase print level')
+    flags = parser.parse_args()
+
+    if flags.blind and flags.reco:
+        raise ValueError('Unable to run blinded and reco modes at the same time')
+    return flags
 
 
 # ---------------------------------------------------------------------------
-# Histogram accumulation helpers
-# ---------------------------------------------------------------------------
-
-def _valid_mask(jet_pt):
-    """Return boolean mask of jets with pt > 0; shape matches jet_pt."""
-    return jet_pt > 0
-
-
-def accumulate_var_histograms(batch_files, var, binning, nominal_wkey, nboot, verbose):
-    """
-    Iterate over batch files and accumulate histogram counts without keeping
-    raw arrays in memory across iterations.
-
-    Parameters
-    ----------
-    batch_files : list of str
-    var : str
-        Observable key in the h5 file.
-    binning : 1-D array
-    nominal_wkey : str
-        Dataset key for the nominal unfolded weight (e.g. 'weights_nominal').
-    nboot : int
-        Number of bootstrap weight sets (weights1..weightsN). Pass 0 to skip.
-    verbose : bool
-
-    Returns
-    -------
-    counts_mc : (n_bins,)      mc_weights only
-    counts_unf : (n_bins,)     mc_weights * nominal_wkey
-    counts_boot : (nboot, n_bins)  mc_weights * weightsI, I = 1..nboot
-    counts_closure : (n_bins,) mc_weights * closure_weights (zeros if key absent)
-    """
-    n_bins = len(binning) - 1
-    counts_mc = np.zeros(n_bins)
-    counts_unf = np.zeros(n_bins)
-    counts_boot = np.zeros((nboot, n_bins))
-    counts_closure = np.zeros(n_bins)
-
-    for fpath in batch_files:
-        if verbose:
-            print(f"  reading {os.path.basename(fpath)}")
-        with h5.File(fpath, "r") as fh5:
-            values = fh5[var][:]
-            jet_pt = fh5["jet_pt"][:]
-            mc_w = fh5["mc_weights"][:]
-            nominal_w = fh5[nominal_wkey][:] if nominal_wkey in fh5 else None
-
-            valid = _valid_mask(jet_pt)
-            per_jet = values.ndim == 2
-
-            if per_jet:
-                flat_vals = values[valid]
-            else:
-                flat_vals = values
-
-            # --- MC (mc_weights only) ---
-            if per_jet:
-                w_mc = np.where(valid, mc_w[:, None], 0.0)[valid]
-            else:
-                w_mc = mc_w
-            counts_mc += np.histogram(flat_vals, bins=binning, weights=w_mc)[0]
-
-            # --- Unfolded (mc_weights * nominal_w) ---
-            if nominal_w is not None:
-                combined = mc_w * nominal_w
-                if per_jet:
-                    w_unf = np.where(valid, combined[:, None], 0.0)[valid]
-                else:
-                    w_unf = combined
-                counts_unf += np.histogram(flat_vals, bins=binning, weights=w_unf)[0]
-
-            # --- Bootstrap ---
-            for i in range(1, nboot + 1):
-                key = f"weights{i}"
-                if key not in fh5:
-                    continue
-                boot_w = fh5[key][:]
-                combined_b = mc_w * boot_w
-                if per_jet:
-                    w_b = np.where(valid, combined_b[:, None], 0.0)[valid]
-                else:
-                    w_b = combined_b
-                counts_boot[i - 1] += np.histogram(flat_vals, bins=binning, weights=w_b)[0]
-
-            # --- Closure (mc_weights * closure_weights) ---
-            if "closure_weights" in fh5:
-                closure_w = fh5["closure_weights"][:]
-                combined_c = mc_w * closure_w
-                if per_jet:
-                    w_c = np.where(valid, combined_c[:, None], 0.0)[valid]
-                else:
-                    w_c = combined_c
-                counts_closure += np.histogram(flat_vals, bins=binning, weights=w_c)[0]
-
-        del values, jet_pt, mc_w, valid
-        gc.collect()
-
-    return counts_mc, counts_unf, counts_boot, counts_closure
-
-
-def accumulate_sys_histogram(batch_files, var, binning, nominal_wkey, verbose):
-    """
-    Accumulate mc_weights * nominal_wkey histogram for a systematic variation.
-    Returns counts_unf of shape (n_bins,).
-    """
-    n_bins = len(binning) - 1
-    counts_unf = np.zeros(n_bins)
-
-    for fpath in batch_files:
-        if verbose:
-            print(f"  reading {os.path.basename(fpath)}")
-        with h5.File(fpath, "r") as fh5:
-            if var not in fh5 or nominal_wkey not in fh5:
-                continue
-            values = fh5[var][:]
-            jet_pt = fh5["jet_pt"][:]
-            mc_w = fh5["mc_weights"][:]
-            nominal_w = fh5[nominal_wkey][:]
-
-            valid = _valid_mask(jet_pt)
-            per_jet = values.ndim == 2
-
-            combined = mc_w * nominal_w
-            if per_jet:
-                flat_vals = values[valid]
-                w_unf = np.where(valid, combined[:, None], 0.0)[valid]
-            else:
-                flat_vals = values
-                w_unf = combined
-            counts_unf += np.histogram(flat_vals, bins=binning, weights=w_unf)[0]
-
-        del values, jet_pt, mc_w, valid
-        gc.collect()
-
-    return counts_unf
-
-
-# ---------------------------------------------------------------------------
-# Uncertainty helpers
-# ---------------------------------------------------------------------------
-
-def bootstrap_stat_unc(counts_boot, binning):
-    """
-    Compute relative statistical uncertainty per bin as std/mean over bootstrap
-    replicas. Returns array of shape (n_bins,) with values in [0, inf).
-    """
-    mean = np.mean(counts_boot, axis=0)
-    std = np.std(counts_boot, axis=0)
-    return np.where(mean > 0, std / mean, 0.0)
-
-
-def systematic_unc(sys_hist, ref_hist):
-    """
-    Fractional systematic uncertainty from one source: |sys/ref - 1|.
-    Returns array of shape (n_bins,).
-    """
-    safe_ref = np.where(ref_hist > 0, ref_hist, np.nan)
-    return np.abs(np.nan_to_num(sys_hist / safe_ref, nan=1.0) - 1.0)
-
-
-# ---------------------------------------------------------------------------
-# Normalise to density
+# Normalisation helper
 # ---------------------------------------------------------------------------
 
 def to_density(counts, binning):
-    """Normalise counts to unit-area density; returns copy."""
+    """Normalise raw counts to unit-area density histogram."""
     bin_widths = np.diff(binning)
     total = np.sum(counts * bin_widths)
     if total <= 0:
@@ -274,236 +140,456 @@ def to_density(counts, binning):
 
 
 # ---------------------------------------------------------------------------
-# Plotting
+# Per-file histogram accumulation helpers
 # ---------------------------------------------------------------------------
 
-def plot_var(var, info, rapgap_mc, rapgap_unf, djangoh_mc,
-             stat_unc, plot_folder, version, total_unc=None, blind=False):
+def _accumulate_eec_file(fh5, binning, weight_keys, include_E_wgt):
     """
-    Build a main + ratio panel plot for one observable and save to PDF.
+    Accumulate EEC histograms from one open h5 file (read fully).
 
-    Parameters
-    ----------
-    var : str
-    info : ObservableInfo
-    rapgap_mc   : density-normalised counts (n_bins,) -- RAPGAP MC only
-    rapgap_unf  : density-normalised counts (n_bins,) -- RAPGAP unfolded (or closure)
-    djangoh_mc  : density-normalised counts (n_bins,) -- DJANGOH MC only
-    stat_unc    : relative stat uncertainty per bin (n_bins,), from bootstrap
-    plot_folder : str
-    version     : str
-    total_unc   : relative total uncertainty per bin (n_bins,), stat + sys combined.
-                  If None, only stat_unc is shown.
-    blind       : if True, label the unfolded points as the closure result
+    weight_keys : list of (label, h5_key_or_None)
+        If h5_key_or_None is not None: weight = mc_weights * fh5[h5_key]
+        If h5_key_or_None is None:     weight = mc_weights only
+    include_E_wgt : bool
+        Multiply pair weights by E_wgt (for plot feed_dict, not systematics).
+
+    Returns dict label -> raw count array of shape (n_bins,).
     """
-    data_name = "Rapgap_closure" if blind else "Data_unfolded"
+    n_bins = len(binning) - 1
+    out = {lbl: np.zeros(n_bins) for lbl, _ in weight_keys}
+
+    eec_vals = fh5['eec'][:]      # (N, P)
+    E_wgt_vals = fh5['E_wgt'][:]  # (N, P)
+    mc_w = fh5['mc_weights'][:]   # (N,)
+    valid = eec_vals != -100      # (N, P)
+
+    for lbl, wk in weight_keys:
+        # 'weights' is absent in bootstrap-mode batch files; fall back to 'weights_nominal'
+        if wk == 'weights' and wk not in fh5 and 'weights_nominal' in fh5:
+            wk = 'weights_nominal'
+        if wk is not None and wk in fh5:
+            event_w = mc_w * fh5[wk][:]
+        else:
+            event_w = mc_w.copy()
+
+        if include_E_wgt:
+            pair_w = event_w[:, None] * E_wgt_vals
+        else:
+            pair_w = np.broadcast_to(event_w[:, None], eec_vals.shape).copy()
+
+        out[lbl] += np.histogram(eec_vals[valid], bins=binning,
+                                 weights=pair_w[valid])[0]
+
+    return out
+
+
+def _accumulate_jet_file(fh5, var, binning, weight_keys):
+    """
+    Accumulate jet-observable histograms from one open h5 file (read fully).
+    Same interface as _accumulate_eec_file (minus include_E_wgt).
+    """
+    n_bins = len(binning) - 1
+    out = {lbl: np.zeros(n_bins) for lbl, _ in weight_keys}
+
+    values = fh5[var][:]        # (N, J) or (N,)
+    jet_pt = fh5['jet_pt'][:]   # (N, J)
+    mc_w = fh5['mc_weights'][:] # (N,)
+
+    per_jet = values.ndim == 2
+    if per_jet:
+        valid = jet_pt > 0
+        flat_vals = values[valid]
+    else:
+        flat_vals = values
+
+    for lbl, wk in weight_keys:
+        # 'weights' is absent in bootstrap-mode batch files; fall back to 'weights_nominal'
+        if wk == 'weights' and wk not in fh5 and 'weights_nominal' in fh5:
+            wk = 'weights_nominal'
+        if wk is not None and wk in fh5:
+            event_w = mc_w * fh5[wk][:]
+        else:
+            event_w = mc_w.copy()
+
+        if per_jet:
+            flat_w = np.broadcast_to(event_w[:, None], values.shape).copy()[valid]
+        else:
+            flat_w = event_w
+
+        out[lbl] += np.histogram(flat_vals, bins=binning, weights=flat_w)[0]
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Multi-file accumulation (iterates over batch file list)
+# ---------------------------------------------------------------------------
+
+def accumulate_histograms(file_list, var, binning, weight_keys,
+                          eec_mode=False, include_E_wgt=False, verbose=False):
+    """
+    Iterate over a list of batch h5 files and accumulate weighted histograms.
+
+    Returns dict: label -> raw count array of shape (n_bins,)
+    """
+    n_bins = len(binning) - 1
+    totals = {lbl: np.zeros(n_bins) for lbl, _ in weight_keys}
+
+    for fpath in file_list:
+        with h5.File(fpath, 'r') as fh5:
+            n_events = fh5['mc_weights'].shape[0]
+            if verbose:
+                print(f'  {os.path.basename(fpath)}  ({n_events} events)')
+            if eec_mode:
+                batch = _accumulate_eec_file(fh5, binning, weight_keys, include_E_wgt)
+            else:
+                batch = _accumulate_jet_file(fh5, var, binning, weight_keys)
+        for lbl in totals:
+            totals[lbl] += batch[lbl]
+        gc.collect()
+
+    return totals
+
+
+def accumulate_bootstrap_histograms(file_list, var, binning, nboot,
+                                    eec_mode=False, include_E_wgt=False,
+                                    verbose=False):
+    """
+    Accumulate one histogram per bootstrap replica (weights1 .. weightsN)
+    across all batch files.
+
+    Returns array of shape (nboot, n_bins) with raw counts.
+    """
+    n_bins = len(binning) - 1
+    boot_counts = np.zeros((nboot, n_bins))
+
+    for fpath in file_list:
+        with h5.File(fpath, 'r') as fh5:
+            n_events = fh5['mc_weights'].shape[0]
+            if verbose:
+                print(f'  [bootstrap] {os.path.basename(fpath)}  ({n_events} events)')
+            weight_keys = [
+                (str(i), f'weights{i}')
+                for i in range(1, nboot)
+                if f'weights{i}' in fh5
+            ]
+            if eec_mode:
+                batch = _accumulate_eec_file(fh5, binning, weight_keys, include_E_wgt)
+            else:
+                batch = _accumulate_jet_file(fh5, var, binning, weight_keys)
+
+        for i in range(1, nboot):
+            if str(i) in batch:
+                boot_counts[i - 1] += batch[str(i)]
+        gc.collect()
+
+    return boot_counts
+
+
+# ---------------------------------------------------------------------------
+# Per-variable plot function
+# ---------------------------------------------------------------------------
+
+def plot_observable(flags, var, batch_files, version):
+    info = ObservableInfo(var)
     binning = info.binning
+    bin_widths = np.diff(binning)
     bin_centers = 0.5 * (binning[:-1] + binning[1:])
-    unc_band = total_unc if total_unc is not None else stat_unc
 
-    fig = plt.figure(figsize=(12, 12))
-    gs = gridspec.GridSpec(2, 1, height_ratios=[3, 1])
-    gs.update(wspace=0.025, hspace=0.1)
-    ax0 = plt.subplot(gs[0])
-    ax1 = plt.subplot(gs[1], sharex=ax0)
-    ax0.xaxis.set_visible(False)
+    eec_mode = flags.eec and var in ('eec', 'theta')
 
-    # ---- main panel ----
-    ax0.stairs(
-        rapgap_mc, binning,
-        color=options.colors["Rapgap"],
-        fill=True, alpha=0.2,
-        label=options.name_translate["Rapgap"],
+    weight_name = 'closure_weights' if flags.blind else 'weights'
+    if flags.blind:
+        data_name = 'Rapgap_closure'
+    elif flags.reco:
+        data_name = 'Rapgap_unfolded'
+    else:
+        data_name = 'Data_unfolded'
+
+    rapgap_files  = batch_files['Rapgap']
+    djangoh_files = batch_files['Djangoh']
+
+    # ------------------------------------------------------------------
+    # Debug: summarise input files and event counts
+    # ------------------------------------------------------------------
+    if flags.verbose:
+        print(f'\n=== {var} ===')
+        for label, flist in batch_files.items():
+            if not flist:
+                print(f'  {label}: no files found')
+                continue
+            total_events = 0
+            for fpath in flist:
+                with h5.File(fpath, 'r') as fh5:
+                    count_key = 'mc_weights' if label != 'data' else 'jet_pt'
+                    total_events += fh5[count_key].shape[0]
+            print(f'  {label}: {len(flist)} file(s), {total_events} events total')
+
+    # ------------------------------------------------------------------
+    # Accumulate raw histograms
+    # ------------------------------------------------------------------
+
+    # Rapgap: always collect mc, weights, and closure_weights separately
+    # so we can replicate plot_part_observable's systematics exactly.
+    if flags.verbose:
+        print(f'Accumulating Rapgap ({var}) ...')
+    rapgap_sys_keys = [
+        ('mc',      None),
+        ('weights', 'weights'),
+        ('closure', 'closure_weights'),
+    ]
+    rapgap_sys = accumulate_histograms(
+        rapgap_files, var, binning, rapgap_sys_keys,
+        eec_mode=eec_mode, include_E_wgt=False, verbose=flags.verbose,
     )
-    ax0.stairs(
-        djangoh_mc, binning,
-        color=options.colors["Djangoh"],
-        linewidth=2,
-        label=options.name_translate["Djangoh"],
-    )
-    ax0.errorbar(
-        bin_centers, rapgap_unf,
-        yerr=[rapgap_unf * stat_unc, rapgap_unf * stat_unc],
-        fmt="o", color=options.colors[data_name],
-        markersize=6,
-        label=options.name_translate[data_name],
-    )
-    # Total uncertainty band on main panel
-    ax0.fill_between(
-        bin_centers,
-        rapgap_unf * (1 - unc_band),
-        rapgap_unf * (1 + unc_band),
-        alpha=0.2, color=options.colors[data_name],
-        step=None,
-    )
 
-    ylabel = r"$1/\sigma$ $\mathrm{d}\sigma/\mathrm{d}$%s" % info.name
-    ax0.set_ylabel(ylabel)
-    if info.logy:
-        ax0.set_yscale("log")
-    if info.logx:
-        ax0.set_xscale("log")
-    ax0.set_ylim(info.ylow, info.yhigh)
-    ax0.legend(loc="upper left")
-    utils.FormatFig(info.name, ylabel, ax0)
-
-    # ---- ratio panel: MC / unfolded ----
-    ref = rapgap_unf
-    safe_ref = np.where(ref > 0, ref, np.nan)
-
-    ratio_rapgap  = rapgap_mc  / safe_ref
-    ratio_djangoh = djangoh_mc / safe_ref
-
-    ax1.stairs(ratio_rapgap,  binning, color=options.colors["Rapgap"],  linewidth=2)
-    ax1.stairs(ratio_djangoh, binning, color=options.colors["Djangoh"], linewidth=2)
-
-    # Total uncertainty band around 1
-    for ibin in range(len(binning) - 1):
-        xlow, xup = binning[ibin], binning[ibin + 1]
-        unc = unc_band[ibin]
-        ax1.fill_between(
-            [xlow, xup], 1.0 - unc, 1.0 + unc,
-            alpha=0.15, color="black",
+    # For the plot feed_dict, include E_wgt in EEC mode
+    if eec_mode:
+        rapgap_plot_keys = [
+            ('mc',       None),
+            ('unfolded', weight_name),
+        ]
+        rapgap_plot = accumulate_histograms(
+            rapgap_files, var, binning, rapgap_plot_keys,
+            eec_mode=True, include_E_wgt=True, verbose=flags.verbose,
         )
-        ax1.bar(
-            (xlow + xup) / 2, 2 * unc, width=(xup - xlow),
-            bottom=1.0 - unc, hatch="//",
-            color="none", edgecolor="grey",
+    else:
+        rapgap_plot = {
+            'mc':       rapgap_sys['mc'],
+            'unfolded': rapgap_sys['closure'] if flags.blind else rapgap_sys['weights'],
+        }
+
+    # Djangoh: mc only (for nominal_closure) + weights (for model uncertainty sys)
+    if flags.verbose:
+        print(f'Accumulating Djangoh ({var}) ...')
+    djangoh_sys = accumulate_histograms(
+        djangoh_files, var, binning, [('mc', None), ('weights', 'weights')],
+        eec_mode=eec_mode, include_E_wgt=False, verbose=flags.verbose,
+    )
+    if eec_mode:
+        djangoh_plot = accumulate_histograms(
+            djangoh_files, var, binning, [('mc', None)],
+            eec_mode=True, include_E_wgt=True, verbose=flags.verbose,
+        )
+    else:
+        djangoh_plot = djangoh_sys
+
+    # Systematic variation files
+    sys_raw = {}
+    if flags.sys:
+        for sys_label, sfiles in batch_files.items():
+            if sys_label in ('Rapgap', 'Djangoh', 'data'):
+                continue
+            if flags.verbose:
+                print(f'Accumulating {sys_label} ({var}) ...')
+            # In reco mode use mc_weights only (unit unfolded weights),
+            # matching plot_part_observable's `if flags.reco: sys_weights = np.ones_like(...)`
+            sys_weight_key = None if flags.reco else 'weights'
+            res = accumulate_histograms(
+                sfiles, var, binning, [('weights', sys_weight_key)],
+                eec_mode=eec_mode, include_E_wgt=False, verbose=flags.verbose,
+            )
+            sys_raw[sys_label] = res['weights']
+
+    # Reco data raw counts (for stat uncertainty)
+    data_raw_counts = None
+    if flags.reco and 'data' in batch_files:
+        if flags.verbose:
+            print(f'Accumulating data counts ({var}) ...')
+        n_bins = len(binning) - 1
+        data_raw_counts = np.zeros(n_bins)
+        for fpath in batch_files['data']:
+            with h5.File(fpath, 'r') as fh5:
+                n_events = fh5['jet_pt'].shape[0]
+                if flags.verbose:
+                    print(f'  {os.path.basename(fpath)}  ({n_events} events)')
+                if eec_mode:
+                    eec_b = fh5['eec'][:]
+                    valid = eec_b != -100
+                    data_raw_counts += np.histogram(eec_b[valid], bins=binning)[0]
+                else:
+                    vals = fh5[var][:]
+                    jpt = fh5['jet_pt'][:]
+                    valid = jpt > 0
+                    flat = vals[valid] if vals.ndim == 2 else vals
+                    data_raw_counts += np.histogram(flat, bins=binning)[0]
+            gc.collect()
+
+    # Bootstrap (weights1..weightsN stored inside the same Rapgap batch files)
+    boot_raw = None
+    if flags.bootstrap:
+        if flags.verbose:
+            print(f'Accumulating bootstrap ({var}) ...')
+        boot_raw = accumulate_bootstrap_histograms(
+            rapgap_files, var, binning, flags.nboot,
+            eec_mode=eec_mode, include_E_wgt=False, verbose=flags.verbose,
         )
 
-    ax1.errorbar(
-        bin_centers, np.ones_like(bin_centers),
-        yerr=stat_unc,
-        fmt="o", color=options.colors[data_name], markersize=6,
+    # ------------------------------------------------------------------
+    # Density-normalise for systematics
+    # ------------------------------------------------------------------
+    # In reco mode, nominal uses mc_weights only (no unfolded reweighting)
+    nominal         = to_density(rapgap_sys['mc'] if flags.reco else rapgap_sys['weights'], binning)
+    nominal_closure = to_density(djangoh_sys['mc'], binning)
+
+    # ------------------------------------------------------------------
+    # Systematic uncertainty -- EXACT same formula as plot_part_observable
+    # ------------------------------------------------------------------
+    total_unc = None
+    data_stat_unc = np.zeros(len(binning) - 1)
+
+    if flags.sys:
+        total_unc = np.zeros(len(binning) - 1)
+
+        all_sources = list(batch_files.keys())
+        for sys_label in all_sources:
+            if flags.reco and sys_label in ('Rapgap', 'Djangoh', 'data'):
+                continue
+
+            print(sys_label)
+
+            if sys_label == 'Rapgap':
+                sys_hist = to_density(
+                    rapgap_sys['mc'] if flags.reco else rapgap_sys['closure'],
+                    binning
+                )
+                ref_hist = nominal_closure
+
+            elif sys_label == 'Djangoh':
+                sys_hist = to_density(djangoh_sys['weights'], binning)
+                ref_hist = nominal
+
+            elif sys_label in sys_raw:
+                sys_hist = to_density(sys_raw[sys_label], binning)
+                ref_hist = nominal
+
+            else:
+                continue
+
+            unc = (np.ma.divide(sys_hist, ref_hist).filled(1) - 1) ** 2
+            total_unc += unc
+            print(f'{sys_label}: max uncertainty = {np.max(np.sqrt(unc)):.4f}')
+
+        # Statistical uncertainties
+        if flags.reco:
+            unc = 1.0 / (1e-9 + data_raw_counts)
+            total_unc += unc
+            data_stat_unc = np.sqrt(unc)
+            print(f'stat: max uncertainty = {np.max(data_stat_unc):.4f}')
+        else:
+            if flags.bootstrap and boot_raw is not None:
+                print('Running over bootstrap entries')
+                valid_boots = [
+                    boot_raw[i - 1]
+                    for i in range(1, flags.nboot)
+                    if np.any(boot_raw[i - 1] > 0)
+                ]
+                if valid_boots:
+                    boot_densities = np.array(
+                        [to_density(b, binning) for b in valid_boots]
+                    )
+                    stat_unc = np.ma.divide(
+                        np.std(boot_densities, axis=0),
+                        np.mean(boot_densities, axis=0),
+                    ).filled(0)
+                    data_stat_unc = stat_unc
+                    total_unc += stat_unc ** 2
+                    print(f'bootstrap: max uncertainty = {np.max(stat_unc):.4f}')
+
+        total_unc = np.sqrt(total_unc)
+
+    # ------------------------------------------------------------------
+    # Build feed_dict for utils.HistRoutine / HistRoutinePart
+    #
+    # Bin-centers trick: pass bin_centers as "data" with
+    # weight = density * bin_width, so np.histogram(..., density=True)
+    # inside HistRoutinePart recovers the pre-computed density exactly.
+    # ------------------------------------------------------------------
+    rapgap_mc_density  = to_density(rapgap_plot['mc'],      binning)
+    rapgap_unf_density = to_density(rapgap_plot['unfolded'], binning)
+    djangoh_mc_density = to_density(djangoh_plot['mc'],      binning)
+
+    feed_dict = {
+        data_name: bin_centers,
+        'Rapgap':  bin_centers,
+        'Djangoh': bin_centers,
+    }
+    weights_dict = {
+        data_name: rapgap_unf_density * bin_widths,
+        'Rapgap':  rapgap_mc_density  * bin_widths,
+        'Djangoh': djangoh_mc_density * bin_widths,
+    }
+
+    if flags.reco and data_raw_counts is not None:
+        data_density = to_density(data_raw_counts, binning)
+        feed_dict['data']    = bin_centers
+        weights_dict['data'] = data_density * bin_widths
+
+    ylabel = (
+        r'1/N $\mathrm{dN}/\mathrm{d}$%s' % info.name
+        if flags.reco
+        else r'$1/\sigma$ $\mathrm{d}\sigma/\mathrm{d}$%s' % info.name
     )
 
-    ax1.axhline(1.0, color="black", linestyle="--", linewidth=1)
-    ax1.set_ylim(0.5, 1.5)
-    ax1.set_ylabel("MC / Unfolded")
-    ax1.set_xlabel(info.name)
-    if info.logx:
-        ax1.set_xscale("log")
+    hist_routine = utils.HistRoutinePart if eec_mode else utils.HistRoutine
+    fig, ax = hist_routine(
+        feed_dict,
+        xlabel=info.name,
+        ylabel=ylabel,
+        weights=weights_dict,
+        logy=info.logy,
+        logx=info.logx,
+        binning=binning,
+        reference_name='data' if flags.reco else data_name,
+        label_loc='upper left',
+        uncertainty=total_unc,
+        stat_uncertainty=data_stat_unc,
+        show_stat_points=not flags.blind,
+    )
 
-    os.makedirs(plot_folder, exist_ok=True)
-    suffix = "closure" if blind else "unfolded"
-    out_path = os.path.join(plot_folder, f"{version}_{var}_{suffix}.pdf")
-    fig.savefig(out_path, bbox_inches="tight")
-    plt.close(fig)
-    print(f"Saved {out_path}")
+    ax.set_ylim(info.ylow, info.yhigh)
+    os.makedirs(flags.plot_folder, exist_ok=True)
+    if flags.blind:
+        plot_tag = 'closure'
+    elif flags.reco:
+        plot_tag = 'reco'
+    else:
+        plot_tag = 'unfolded'
+    fig.savefig(os.path.join(flags.plot_folder, f'{version}_{var}_{plot_tag}.pdf'))
 
 
 # ---------------------------------------------------------------------------
-# Main
+# Entry point
 # ---------------------------------------------------------------------------
 
 def main():
     flags = parse_arguments()
+    opt = utils.LoadJson(flags.config)
 
-    replace_string = f"unfolded_{flags.niter}_centauro_boot"
-    rapgap_pattern  = os.path.join(
-        flags.data_folder, f"Rapgap_{flags.period}_{replace_string}_batch*.h5"
+    batch_files = get_batch_files(
+        data_folder=flags.data_folder,
+        period=flags.period,
+        niter=flags.niter,
+        suffix=flags.suffix,
+        use_sys=flags.sys,
+        reco=flags.reco,
     )
-    djangoh_pattern = os.path.join(
-        flags.data_folder, f"Djangoh_{flags.period}_{replace_string}_batch*.h5"
-    )
 
-    rapgap_files  = sorted(glob.glob(rapgap_pattern))
-    djangoh_files = sorted(glob.glob(djangoh_pattern))
+    for label, files in batch_files.items():
+        if not files:
+            print(f'WARNING: no batch files found for {label}, skipping')
+        else:
+            print(f'{label}: {len(files)} file(s)')
+            for f in files:
+                print(f'  {os.path.basename(f)}')
 
-    if not rapgap_files:
-        raise FileNotFoundError(f"No Rapgap batch files found: {rapgap_pattern}")
-    if not djangoh_files:
-        raise FileNotFoundError(f"No Djangoh batch files found: {djangoh_pattern}")
+    version = opt['NAME']
 
-    print(f"Found {len(rapgap_files)} Rapgap  batch files")
-    print(f"Found {len(djangoh_files)} Djangoh batch files")
-
-    # Collect systematic batch file lists once
-    sys_files = {}
-    if flags.sys:
-        for sys_label in flags.sys_list:
-            pattern = os.path.join(
-                flags.data_folder,
-                f"Rapgap_{flags.period}_{sys_label}_{replace_string}_batch*.h5",
-            )
-            files = sorted(glob.glob(pattern))
-            if not files:
-                print(f"WARNING: no batch files found for {sys_label} ({pattern}), skipping")
-            else:
-                print(f"Found {len(files)} batch files for {sys_label}")
-                sys_files[sys_label] = files
-
-    version = f"Rapgap_{flags.period}"
-
-    for var in VAR_NAMES:
-        info = ObservableInfo(var)
-        binning = info.binning
-        print(f"\n--- {var} ---")
-
-        print("  Rapgap ...")
-        rapgap_mc_raw, rapgap_unf_raw, rapgap_boot_raw, rapgap_closure_raw = accumulate_var_histograms(
-            rapgap_files, var, binning,
-            flags.nominal_weight, flags.nboot, flags.verbose,
-        )
-
-        print("  Djangoh ...")
-        djangoh_mc_raw, _, _, _ = accumulate_var_histograms(
-            djangoh_files, var, binning,
-            flags.nominal_weight, 0, flags.verbose,
-        )
-
-        # Normalise to density
-        rapgap_mc      = to_density(rapgap_mc_raw,      binning)
-        rapgap_unf     = to_density(rapgap_unf_raw,     binning)
-        rapgap_closure = to_density(rapgap_closure_raw, binning)
-        djangoh_mc     = to_density(djangoh_mc_raw,     binning)
-
-        # Statistical uncertainty from bootstrap replicas
-        stat_unc = bootstrap_stat_unc(rapgap_boot_raw, binning)
-
-        # Systematic uncertainties
-        total_unc = None
-        if flags.sys:
-            total_unc_sq = stat_unc ** 2
-
-            # Model uncertainty: Rapgap closure vs Djangoh MC (matches plot_from_file)
-            has_closure = np.any(rapgap_closure > 0)
-            if not has_closure:
-                print("  WARNING: no closure_weights found in Rapgap batch files; skipping model uncertainty")
-            else:
-                model_unc = systematic_unc(rapgap_closure, djangoh_mc)
-                total_unc_sq += model_unc ** 2
-                print(f"  model: max unc = {np.max(model_unc):.4f}")
-
-            # Each systematic variation
-            for sys_label, sfiles in sys_files.items():
-                print(f"  {sys_label} ...")
-                sys_raw = accumulate_sys_histogram(
-                    sfiles, var, binning, flags.nominal_weight, flags.verbose
-                )
-                sys_hist = to_density(sys_raw, binning)
-                unc = systematic_unc(sys_hist, rapgap_unf)
-                total_unc_sq += unc ** 2
-                print(f"  {sys_label}: max unc = {np.max(unc):.4f}")
-                del sys_raw, sys_hist
-                gc.collect()
-
-            total_unc = np.sqrt(total_unc_sq)
-            print(f"  total: max unc = {np.max(total_unc):.4f}")
-
-        plot_ref = rapgap_closure if flags.blind else rapgap_unf
-        plot_var(
-            var, info,
-            rapgap_mc, plot_ref, djangoh_mc,
-            stat_unc,
-            flags.plot_folder, version,
-            total_unc=total_unc,
-            blind=flags.blind,
-        )
-
-        del rapgap_mc_raw, rapgap_unf_raw, rapgap_boot_raw, rapgap_closure_raw, djangoh_mc_raw
-        gc.collect()
+    for var in var_names:
+        if 'weight' in var:
+            continue
+        plot_observable(flags, var, batch_files, version)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/scripts/plot_from_batches.py
+++ b/scripts/plot_from_batches.py
@@ -1,0 +1,509 @@
+"""
+plot_from_batches.py
+
+Loads Rapgap and Djangoh batch h5 files one at a time and accumulates weighted
+histograms to avoid holding all events in memory simultaneously.
+
+Expected h5 keys per batch file:
+  jet_pt, jet_breit_pt, deltaphi, jet_tau10, zjet, zjet_breit  -- shape (n_events, n_jets)
+  mc_weights                                                     -- shape (n_events,)
+  weights_nominal                                                -- shape (n_events,)  [nominal unfolded]
+  weights1 .. weightsN                                           -- shape (n_events,)  [bootstrap]
+"""
+
+import argparse
+import glob
+import os
+import gc
+
+import numpy as np
+import h5py as h5
+import matplotlib.pyplot as plt
+from matplotlib import gridspec
+from matplotlib.patches import Patch
+
+import utils
+import options
+from utils import ObservableInfo
+
+utils.SetStyle()
+
+VAR_NAMES = [
+    "jet_pt",
+    "jet_breit_pt",
+    "deltaphi",
+    "jet_tau10",
+    "zjet",
+    "zjet_breit",
+]
+
+SYS_LIST_DEFAULT = ["sys0", "sys1", "sys5", "sys7", "sys11"]
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description="Plot unfolded observables from batch h5 files without loading all data at once."
+    )
+    parser.add_argument(
+        "--data_folder",
+        default="/global/cfs/cdirs/m3246/H1/h5",
+        help="Directory containing the batch h5 files",
+    )
+    parser.add_argument(
+        "--plot_folder",
+        default="../plots",
+        help="Directory to write output PDF plots",
+    )
+    parser.add_argument(
+        "--niter", type=int, default=4, help="OmniFold iteration used in file names"
+    )
+    parser.add_argument(
+        "--period", default="Eplus0607", help="Data-taking period string in file names"
+    )
+    parser.add_argument(
+        "--nboot",
+        type=int,
+        default=49,
+        help="Number of bootstrap weight sets (weights1..weightsN) to use for stat uncertainty",
+    )
+    parser.add_argument(
+        "--nominal_weight",
+        default="weights_nominal",
+        help="Key to use as the nominal unfolded weight (default: weights_nominal)",
+    )
+    parser.add_argument(
+        "--sys",
+        action="store_true",
+        default=False,
+        help="Load systematic variation batch files and compute systematic uncertainties",
+    )
+    parser.add_argument(
+        "--sys_list",
+        nargs="+",
+        default=SYS_LIST_DEFAULT,
+        help="List of systematic labels to include (default: sys0 sys1 sys5 sys7 sys11)",
+    )
+    parser.add_argument(
+        "--blind",
+        action="store_true",
+        default=False,
+        help="Closure mode: plot closure_weights result vs RAPGAP truth instead of data",
+    )
+    parser.add_argument(
+        "--verbose", action="store_true", default=False
+    )
+    return parser.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# Histogram accumulation helpers
+# ---------------------------------------------------------------------------
+
+def _valid_mask(jet_pt):
+    """Return boolean mask of jets with pt > 0; shape matches jet_pt."""
+    return jet_pt > 0
+
+
+def accumulate_var_histograms(batch_files, var, binning, nominal_wkey, nboot, verbose):
+    """
+    Iterate over batch files and accumulate histogram counts without keeping
+    raw arrays in memory across iterations.
+
+    Parameters
+    ----------
+    batch_files : list of str
+    var : str
+        Observable key in the h5 file.
+    binning : 1-D array
+    nominal_wkey : str
+        Dataset key for the nominal unfolded weight (e.g. 'weights_nominal').
+    nboot : int
+        Number of bootstrap weight sets (weights1..weightsN). Pass 0 to skip.
+    verbose : bool
+
+    Returns
+    -------
+    counts_mc : (n_bins,)      mc_weights only
+    counts_unf : (n_bins,)     mc_weights * nominal_wkey
+    counts_boot : (nboot, n_bins)  mc_weights * weightsI, I = 1..nboot
+    counts_closure : (n_bins,) mc_weights * closure_weights (zeros if key absent)
+    """
+    n_bins = len(binning) - 1
+    counts_mc = np.zeros(n_bins)
+    counts_unf = np.zeros(n_bins)
+    counts_boot = np.zeros((nboot, n_bins))
+    counts_closure = np.zeros(n_bins)
+
+    for fpath in batch_files:
+        if verbose:
+            print(f"  reading {os.path.basename(fpath)}")
+        with h5.File(fpath, "r") as fh5:
+            values = fh5[var][:]
+            jet_pt = fh5["jet_pt"][:]
+            mc_w = fh5["mc_weights"][:]
+            nominal_w = fh5[nominal_wkey][:] if nominal_wkey in fh5 else None
+
+            valid = _valid_mask(jet_pt)
+            per_jet = values.ndim == 2
+
+            if per_jet:
+                flat_vals = values[valid]
+            else:
+                flat_vals = values
+
+            # --- MC (mc_weights only) ---
+            if per_jet:
+                w_mc = np.where(valid, mc_w[:, None], 0.0)[valid]
+            else:
+                w_mc = mc_w
+            counts_mc += np.histogram(flat_vals, bins=binning, weights=w_mc)[0]
+
+            # --- Unfolded (mc_weights * nominal_w) ---
+            if nominal_w is not None:
+                combined = mc_w * nominal_w
+                if per_jet:
+                    w_unf = np.where(valid, combined[:, None], 0.0)[valid]
+                else:
+                    w_unf = combined
+                counts_unf += np.histogram(flat_vals, bins=binning, weights=w_unf)[0]
+
+            # --- Bootstrap ---
+            for i in range(1, nboot + 1):
+                key = f"weights{i}"
+                if key not in fh5:
+                    continue
+                boot_w = fh5[key][:]
+                combined_b = mc_w * boot_w
+                if per_jet:
+                    w_b = np.where(valid, combined_b[:, None], 0.0)[valid]
+                else:
+                    w_b = combined_b
+                counts_boot[i - 1] += np.histogram(flat_vals, bins=binning, weights=w_b)[0]
+
+            # --- Closure (mc_weights * closure_weights) ---
+            if "closure_weights" in fh5:
+                closure_w = fh5["closure_weights"][:]
+                combined_c = mc_w * closure_w
+                if per_jet:
+                    w_c = np.where(valid, combined_c[:, None], 0.0)[valid]
+                else:
+                    w_c = combined_c
+                counts_closure += np.histogram(flat_vals, bins=binning, weights=w_c)[0]
+
+        del values, jet_pt, mc_w, valid
+        gc.collect()
+
+    return counts_mc, counts_unf, counts_boot, counts_closure
+
+
+def accumulate_sys_histogram(batch_files, var, binning, nominal_wkey, verbose):
+    """
+    Accumulate mc_weights * nominal_wkey histogram for a systematic variation.
+    Returns counts_unf of shape (n_bins,).
+    """
+    n_bins = len(binning) - 1
+    counts_unf = np.zeros(n_bins)
+
+    for fpath in batch_files:
+        if verbose:
+            print(f"  reading {os.path.basename(fpath)}")
+        with h5.File(fpath, "r") as fh5:
+            if var not in fh5 or nominal_wkey not in fh5:
+                continue
+            values = fh5[var][:]
+            jet_pt = fh5["jet_pt"][:]
+            mc_w = fh5["mc_weights"][:]
+            nominal_w = fh5[nominal_wkey][:]
+
+            valid = _valid_mask(jet_pt)
+            per_jet = values.ndim == 2
+
+            combined = mc_w * nominal_w
+            if per_jet:
+                flat_vals = values[valid]
+                w_unf = np.where(valid, combined[:, None], 0.0)[valid]
+            else:
+                flat_vals = values
+                w_unf = combined
+            counts_unf += np.histogram(flat_vals, bins=binning, weights=w_unf)[0]
+
+        del values, jet_pt, mc_w, valid
+        gc.collect()
+
+    return counts_unf
+
+
+# ---------------------------------------------------------------------------
+# Uncertainty helpers
+# ---------------------------------------------------------------------------
+
+def bootstrap_stat_unc(counts_boot, binning):
+    """
+    Compute relative statistical uncertainty per bin as std/mean over bootstrap
+    replicas. Returns array of shape (n_bins,) with values in [0, inf).
+    """
+    mean = np.mean(counts_boot, axis=0)
+    std = np.std(counts_boot, axis=0)
+    return np.where(mean > 0, std / mean, 0.0)
+
+
+def systematic_unc(sys_hist, ref_hist):
+    """
+    Fractional systematic uncertainty from one source: |sys/ref - 1|.
+    Returns array of shape (n_bins,).
+    """
+    safe_ref = np.where(ref_hist > 0, ref_hist, np.nan)
+    return np.abs(np.nan_to_num(sys_hist / safe_ref, nan=1.0) - 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Normalise to density
+# ---------------------------------------------------------------------------
+
+def to_density(counts, binning):
+    """Normalise counts to unit-area density; returns copy."""
+    bin_widths = np.diff(binning)
+    total = np.sum(counts * bin_widths)
+    if total <= 0:
+        return counts.copy()
+    return counts / total
+
+
+# ---------------------------------------------------------------------------
+# Plotting
+# ---------------------------------------------------------------------------
+
+def plot_var(var, info, rapgap_mc, rapgap_unf, djangoh_mc,
+             stat_unc, plot_folder, version, total_unc=None, blind=False):
+    """
+    Build a main + ratio panel plot for one observable and save to PDF.
+
+    Parameters
+    ----------
+    var : str
+    info : ObservableInfo
+    rapgap_mc   : density-normalised counts (n_bins,) -- RAPGAP MC only
+    rapgap_unf  : density-normalised counts (n_bins,) -- RAPGAP unfolded (or closure)
+    djangoh_mc  : density-normalised counts (n_bins,) -- DJANGOH MC only
+    stat_unc    : relative stat uncertainty per bin (n_bins,), from bootstrap
+    plot_folder : str
+    version     : str
+    total_unc   : relative total uncertainty per bin (n_bins,), stat + sys combined.
+                  If None, only stat_unc is shown.
+    blind       : if True, label the unfolded points as the closure result
+    """
+    data_name = "Rapgap_closure" if blind else "Data_unfolded"
+    binning = info.binning
+    bin_centers = 0.5 * (binning[:-1] + binning[1:])
+    unc_band = total_unc if total_unc is not None else stat_unc
+
+    fig = plt.figure(figsize=(12, 12))
+    gs = gridspec.GridSpec(2, 1, height_ratios=[3, 1])
+    gs.update(wspace=0.025, hspace=0.1)
+    ax0 = plt.subplot(gs[0])
+    ax1 = plt.subplot(gs[1], sharex=ax0)
+    ax0.xaxis.set_visible(False)
+
+    # ---- main panel ----
+    ax0.stairs(
+        rapgap_mc, binning,
+        color=options.colors["Rapgap"],
+        fill=True, alpha=0.2,
+        label=options.name_translate["Rapgap"],
+    )
+    ax0.stairs(
+        djangoh_mc, binning,
+        color=options.colors["Djangoh"],
+        linewidth=2,
+        label=options.name_translate["Djangoh"],
+    )
+    ax0.errorbar(
+        bin_centers, rapgap_unf,
+        yerr=[rapgap_unf * stat_unc, rapgap_unf * stat_unc],
+        fmt="o", color=options.colors[data_name],
+        markersize=6,
+        label=options.name_translate[data_name],
+    )
+    # Total uncertainty band on main panel
+    ax0.fill_between(
+        bin_centers,
+        rapgap_unf * (1 - unc_band),
+        rapgap_unf * (1 + unc_band),
+        alpha=0.2, color=options.colors[data_name],
+        step=None,
+    )
+
+    ylabel = r"$1/\sigma$ $\mathrm{d}\sigma/\mathrm{d}$%s" % info.name
+    ax0.set_ylabel(ylabel)
+    if info.logy:
+        ax0.set_yscale("log")
+    if info.logx:
+        ax0.set_xscale("log")
+    ax0.set_ylim(info.ylow, info.yhigh)
+    ax0.legend(loc="upper left")
+    utils.FormatFig(info.name, ylabel, ax0)
+
+    # ---- ratio panel: MC / unfolded ----
+    ref = rapgap_unf
+    safe_ref = np.where(ref > 0, ref, np.nan)
+
+    ratio_rapgap  = rapgap_mc  / safe_ref
+    ratio_djangoh = djangoh_mc / safe_ref
+
+    ax1.stairs(ratio_rapgap,  binning, color=options.colors["Rapgap"],  linewidth=2)
+    ax1.stairs(ratio_djangoh, binning, color=options.colors["Djangoh"], linewidth=2)
+
+    # Total uncertainty band around 1
+    for ibin in range(len(binning) - 1):
+        xlow, xup = binning[ibin], binning[ibin + 1]
+        unc = unc_band[ibin]
+        ax1.fill_between(
+            [xlow, xup], 1.0 - unc, 1.0 + unc,
+            alpha=0.15, color="black",
+        )
+        ax1.bar(
+            (xlow + xup) / 2, 2 * unc, width=(xup - xlow),
+            bottom=1.0 - unc, hatch="//",
+            color="none", edgecolor="grey",
+        )
+
+    ax1.errorbar(
+        bin_centers, np.ones_like(bin_centers),
+        yerr=stat_unc,
+        fmt="o", color=options.colors[data_name], markersize=6,
+    )
+
+    ax1.axhline(1.0, color="black", linestyle="--", linewidth=1)
+    ax1.set_ylim(0.5, 1.5)
+    ax1.set_ylabel("MC / Unfolded")
+    ax1.set_xlabel(info.name)
+    if info.logx:
+        ax1.set_xscale("log")
+
+    os.makedirs(plot_folder, exist_ok=True)
+    suffix = "closure" if blind else "unfolded"
+    out_path = os.path.join(plot_folder, f"{version}_{var}_{suffix}.pdf")
+    fig.savefig(out_path, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved {out_path}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    flags = parse_arguments()
+
+    replace_string = f"unfolded_{flags.niter}_centauro_boot"
+    rapgap_pattern  = os.path.join(
+        flags.data_folder, f"Rapgap_{flags.period}_{replace_string}_batch*.h5"
+    )
+    djangoh_pattern = os.path.join(
+        flags.data_folder, f"Djangoh_{flags.period}_{replace_string}_batch*.h5"
+    )
+
+    rapgap_files  = sorted(glob.glob(rapgap_pattern))
+    djangoh_files = sorted(glob.glob(djangoh_pattern))
+
+    if not rapgap_files:
+        raise FileNotFoundError(f"No Rapgap batch files found: {rapgap_pattern}")
+    if not djangoh_files:
+        raise FileNotFoundError(f"No Djangoh batch files found: {djangoh_pattern}")
+
+    print(f"Found {len(rapgap_files)} Rapgap  batch files")
+    print(f"Found {len(djangoh_files)} Djangoh batch files")
+
+    # Collect systematic batch file lists once
+    sys_files = {}
+    if flags.sys:
+        for sys_label in flags.sys_list:
+            pattern = os.path.join(
+                flags.data_folder,
+                f"Rapgap_{flags.period}_{sys_label}_{replace_string}_batch*.h5",
+            )
+            files = sorted(glob.glob(pattern))
+            if not files:
+                print(f"WARNING: no batch files found for {sys_label} ({pattern}), skipping")
+            else:
+                print(f"Found {len(files)} batch files for {sys_label}")
+                sys_files[sys_label] = files
+
+    version = f"Rapgap_{flags.period}"
+
+    for var in VAR_NAMES:
+        info = ObservableInfo(var)
+        binning = info.binning
+        print(f"\n--- {var} ---")
+
+        print("  Rapgap ...")
+        rapgap_mc_raw, rapgap_unf_raw, rapgap_boot_raw, rapgap_closure_raw = accumulate_var_histograms(
+            rapgap_files, var, binning,
+            flags.nominal_weight, flags.nboot, flags.verbose,
+        )
+
+        print("  Djangoh ...")
+        djangoh_mc_raw, _, _, _ = accumulate_var_histograms(
+            djangoh_files, var, binning,
+            flags.nominal_weight, 0, flags.verbose,
+        )
+
+        # Normalise to density
+        rapgap_mc      = to_density(rapgap_mc_raw,      binning)
+        rapgap_unf     = to_density(rapgap_unf_raw,     binning)
+        rapgap_closure = to_density(rapgap_closure_raw, binning)
+        djangoh_mc     = to_density(djangoh_mc_raw,     binning)
+
+        # Statistical uncertainty from bootstrap replicas
+        stat_unc = bootstrap_stat_unc(rapgap_boot_raw, binning)
+
+        # Systematic uncertainties
+        total_unc = None
+        if flags.sys:
+            total_unc_sq = stat_unc ** 2
+
+            # Model uncertainty: Rapgap closure vs Djangoh MC (matches plot_from_file)
+            has_closure = np.any(rapgap_closure > 0)
+            if not has_closure:
+                print("  WARNING: no closure_weights found in Rapgap batch files; skipping model uncertainty")
+            else:
+                model_unc = systematic_unc(rapgap_closure, djangoh_mc)
+                total_unc_sq += model_unc ** 2
+                print(f"  model: max unc = {np.max(model_unc):.4f}")
+
+            # Each systematic variation
+            for sys_label, sfiles in sys_files.items():
+                print(f"  {sys_label} ...")
+                sys_raw = accumulate_sys_histogram(
+                    sfiles, var, binning, flags.nominal_weight, flags.verbose
+                )
+                sys_hist = to_density(sys_raw, binning)
+                unc = systematic_unc(sys_hist, rapgap_unf)
+                total_unc_sq += unc ** 2
+                print(f"  {sys_label}: max unc = {np.max(unc):.4f}")
+                del sys_raw, sys_hist
+                gc.collect()
+
+            total_unc = np.sqrt(total_unc_sq)
+            print(f"  total: max unc = {np.max(total_unc):.4f}")
+
+        plot_ref = rapgap_closure if flags.blind else rapgap_unf
+        plot_var(
+            var, info,
+            rapgap_mc, plot_ref, djangoh_mc,
+            stat_unc,
+            flags.plot_folder, version,
+            total_unc=total_unc,
+            blind=flags.blind,
+        )
+
+        del rapgap_mc_raw, rapgap_unf_raw, rapgap_boot_raw, rapgap_closure_raw, djangoh_mc_raw
+        gc.collect()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plot_from_batches.py
+++ b/scripts/plot_from_batches.py
@@ -137,16 +137,13 @@ def parse_arguments():
 # ---------------------------------------------------------------------------
 # Normalisation helper
 # ---------------------------------------------------------------------------
-
 def to_density(counts, binning):
     """Normalise raw counts to unit-area density histogram."""
     bin_widths = np.diff(binning)
-    total = np.sum(counts * bin_widths)
+    total = np.sum(counts)
     if total <= 0:
         return counts.copy()
-    return counts / total
-
-
+    return counts / (total*bin_widths)
 # ---------------------------------------------------------------------------
 # Per-file histogram accumulation helpers
 # ---------------------------------------------------------------------------
@@ -299,6 +296,7 @@ def accumulate_bootstrap_histograms(file_list, var, binning, nboot,
 # ---------------------------------------------------------------------------
 
 def load_pythia_histogram(root_file, var, binning):
+    import awkward as ak
     """
     Load a normalised density histogram for `var` from a Pythia ROOT file.
 
@@ -307,19 +305,16 @@ def load_pythia_histogram(root_file, var, binning):
     Returns (bin_centers, density_weights) suitable for feed_dict / weights_dict,
     or None if the variable is not present in the file.
     """
-    with uproot.open(root_file) as f:
+   with uproot.open(root_file) as f:
         tree = f['jets']
         if var not in tree.keys():
             return None
-        vals = tree[var].array(library='np')  # flat or jagged array
-        if vals.dtype == object:              # jagged: flatten across events
-            vals = np.concatenate(vals)
-
-    bin_widths = np.diff(binning)
+        vals = tree[var].array()  # flat or jagged array
+        if vals.ndim == 2:
+            vals = ak.flatten(vals)
     counts, _ = np.histogram(vals, bins=binning)
-    density = to_density(counts.astype(float), binning)
     bin_centers = 0.5 * (binning[:-1] + binning[1:])
-    return bin_centers, density * bin_widths
+    return bin_centers, counts
 
 
 # ---------------------------------------------------------------------------
@@ -534,16 +529,6 @@ def plot_observable(flags, var, batch_files, version):
 
         total_unc = np.sqrt(total_unc)
 
-    # ------------------------------------------------------------------
-    # Build feed_dict for utils.HistRoutine / HistRoutinePart
-    #
-    # Bin-centers trick: pass bin_centers as "data" with
-    # weight = density * bin_width, so np.histogram(..., density=True)
-    # inside HistRoutinePart recovers the pre-computed density exactly.
-    # ------------------------------------------------------------------
-    rapgap_mc_density  = to_density(rapgap_plot['mc'],      binning)
-    rapgap_unf_density = to_density(rapgap_plot['unfolded'], binning)
-    djangoh_mc_density = to_density(djangoh_plot['mc'],      binning)
 
     feed_dict = {
         data_name: bin_centers,
@@ -551,9 +536,9 @@ def plot_observable(flags, var, batch_files, version):
         'Djangoh': bin_centers,
     }
     weights_dict = {
-        data_name: rapgap_unf_density * bin_widths,
-        'Rapgap':  rapgap_mc_density  * bin_widths,
-        'Djangoh': djangoh_mc_density * bin_widths,
+        data_name: rapgap_plot['unfolded'],
+        'Rapgap':  rapgap_plot['mc'],
+        'Djangoh': djangoh_plot['mc'],
     }
 
     if flags.pythia is not None:

--- a/scripts/plot_from_batches.py
+++ b/scripts/plot_from_batches.py
@@ -26,6 +26,7 @@ import gc
 
 import numpy as np
 import h5py as h5
+import uproot
 
 import utils
 import options
@@ -34,6 +35,7 @@ from utils import ObservableInfo
 utils.SetStyle()
 
 var_names = ['deltaphi', 'jet_pt', 'jet_tau10', 'zjet', 'zjet_breit']#, 'eec', 'theta']
+# var_names = ['deltaphi']#, 'eec', 'theta']
 
 
 # ---------------------------------------------------------------------------
@@ -42,7 +44,7 @@ var_names = ['deltaphi', 'jet_pt', 'jet_tau10', 'zjet', 'zjet_breit']#, 'eec', '
 
 def get_batch_files(data_folder, period, niter, suffix,
                     use_sys, sys_list=None, nominal='Rapgap',
-                    reco=False):
+                    reco=False, data_suffix=None):
     """
     Return a dict mapping dataset label -> sorted list of batch h5 file paths.
 
@@ -50,12 +52,12 @@ def get_batch_files(data_folder, period, niter, suffix,
       Rapgap_Eplus0607_unfolded_4_centauro_boot_batch0000.h5
       Rapgap_Eplus0607_sys0_unfolded_4_centauro_boot_batch0000.h5
       Djangoh_Eplus0607_unfolded_4_centauro_boot_batch0000.h5
-      data_Eplus0607_unfolded_4_centauro_reco_batch0000.h5  (reco mode, data only)
+      data_Eplus0607_unfolded_4_reco_batch0000.h5  (reco mode, data only)
     """
     if sys_list is None:
         sys_list = ['sys0', 'sys1', 'sys5', 'sys7', 'sys11']
 
-    mc_suffix = suffix.replace('_boot', '_reco_boot') if reco else suffix
+    mc_suffix = suffix.replace('boot', 'reco_boot') if reco else suffix
 
     def _glob(base_name):
         pattern = os.path.join(
@@ -71,10 +73,11 @@ def get_batch_files(data_folder, period, niter, suffix,
     }
 
     if reco:
-        reco_data_suffix = suffix.replace('_boot', '') + '_reco'
+        if data_suffix is None:
+            data_suffix = suffix.replace('boot', 'reco')
         data_pattern = os.path.join(
             data_folder,
-            f'data_{period}_unfolded_{niter}_{reco_data_suffix}_batch*.h5'
+            f'data_{period}_unfolded_{niter}_{data_suffix}_batch*.h5'
         )
         batch_files['data'] = sorted(glob.glob(data_pattern))
 
@@ -101,8 +104,11 @@ def parse_arguments():
                         help='Folder to store plots')
     parser.add_argument('--period', default='Eplus0607',
                         help='Data-taking period string in file names')
-    parser.add_argument('--suffix', default='centauro_boot',
-                        help='Middle suffix in batch file names (e.g. centauro_boot)')
+    parser.add_argument('--suffix', default='boot',
+                        help='Middle suffix in batch file names (e.g. boot)')
+    parser.add_argument('--data_suffix', default=None,
+                        help='Suffix for data batch file names in reco mode (e.g. reco). '
+                             'Defaults to <suffix-without-_boot>_reco if not set.')
     parser.add_argument('--reco', action='store_true', default=False,
                         help='Plot reco level results')
     parser.add_argument('--sys', action='store_true', default=False,
@@ -117,6 +123,8 @@ def parse_arguments():
                         help='Number of bootstrap replicas (weights1..weightsN) in the files')
     parser.add_argument('--eec', action='store_true', default=False,
                         help='Use eec mask and E_wgt (EEC mode)')
+    parser.add_argument('--pythia', default=None,
+                        help='Path to Pythia ROOT file with tree "jets" for theory curve')
     parser.add_argument('--verbose', action='store_true', default=False,
                         help='Increase print level')
     flags = parser.parse_args()
@@ -284,6 +292,34 @@ def accumulate_bootstrap_histograms(file_list, var, binning, nboot,
         gc.collect()
 
     return boot_counts
+
+
+# ---------------------------------------------------------------------------
+# Pythia theory prediction loader
+# ---------------------------------------------------------------------------
+
+def load_pythia_histogram(root_file, var, binning):
+    """
+    Load a normalised density histogram for `var` from a Pythia ROOT file.
+
+    The tree "jets" stores observables as flat arrays (e.g. jet_pt) with
+    companion count arrays (e.g. njet_pt) giving the multiplicity per event.
+    Returns (bin_centers, density_weights) suitable for feed_dict / weights_dict,
+    or None if the variable is not present in the file.
+    """
+    with uproot.open(root_file) as f:
+        tree = f['jets']
+        if var not in tree.keys():
+            return None
+        vals = tree[var].array(library='np')  # flat or jagged array
+        if vals.dtype == object:              # jagged: flatten across events
+            vals = np.concatenate(vals)
+
+    bin_widths = np.diff(binning)
+    counts, _ = np.histogram(vals, bins=binning)
+    density = to_density(counts.astype(float), binning)
+    bin_centers = 0.5 * (binning[:-1] + binning[1:])
+    return bin_centers, density * bin_widths
 
 
 # ---------------------------------------------------------------------------
@@ -520,6 +556,14 @@ def plot_observable(flags, var, batch_files, version):
         'Djangoh': djangoh_mc_density * bin_widths,
     }
 
+    if flags.pythia is not None:
+        pythia_result = load_pythia_histogram(flags.pythia, var, binning)
+        if pythia_result is not None:
+            feed_dict['Pythia']    = pythia_result[0]
+            weights_dict['Pythia'] = pythia_result[1]
+        elif flags.verbose:
+            print(f'  Pythia: variable "{var}" not found in {flags.pythia}')
+
     if flags.reco and data_raw_counts is not None:
         data_density = to_density(data_raw_counts, binning)
         feed_dict['data']    = bin_centers
@@ -548,6 +592,16 @@ def plot_observable(flags, var, batch_files, version):
     )
 
     ax.set_ylim(info.ylow, info.yhigh)
+
+    if flags.period.startswith('Eplus'):
+        beam_label = '$e^+$'
+    elif flags.period.startswith('Eminus'):
+        beam_label = '$e^-$'
+    else:
+        beam_label = flags.period
+    ax.text(0.97, 0.97, beam_label, transform=ax.transAxes,
+            ha='right', va='top', fontsize=20)
+
     os.makedirs(flags.plot_folder, exist_ok=True)
     if flags.blind:
         plot_tag = 'closure'
@@ -555,7 +609,7 @@ def plot_observable(flags, var, batch_files, version):
         plot_tag = 'reco'
     else:
         plot_tag = 'unfolded'
-    fig.savefig(os.path.join(flags.plot_folder, f'{version}_{var}_{plot_tag}.pdf'))
+    fig.savefig(os.path.join(flags.plot_folder, f'{version}_{flags.period}_{var}_{plot_tag}.pdf'))
 
 
 # ---------------------------------------------------------------------------
@@ -573,6 +627,7 @@ def main():
         suffix=flags.suffix,
         use_sys=flags.sys,
         reco=flags.reco,
+        data_suffix=flags.data_suffix,
     )
 
     for label, files in batch_files.items():

--- a/scripts/plot_from_batches.py
+++ b/scripts/plot_from_batches.py
@@ -305,7 +305,7 @@ def load_pythia_histogram(root_file, var, binning):
     Returns (bin_centers, density_weights) suitable for feed_dict / weights_dict,
     or None if the variable is not present in the file.
     """
-   with uproot.open(root_file) as f:
+    with uproot.open(root_file) as f:
         tree = f['jets']
         if var not in tree.keys():
             return None

--- a/scripts/plot_from_batches.py
+++ b/scripts/plot_from_batches.py
@@ -44,7 +44,7 @@ var_names = ['deltaphi', 'jet_pt', 'jet_tau10', 'zjet', 'zjet_breit']#, 'eec', '
 
 def get_batch_files(data_folder, period, niter, suffix,
                     use_sys, sys_list=None, nominal='Rapgap',
-                    reco=False, data_suffix=None):
+                    reco=False, data_suffix=None, bootstrap=False):
     """
     Return a dict mapping dataset label -> sorted list of batch h5 file paths.
 
@@ -59,16 +59,17 @@ def get_batch_files(data_folder, period, niter, suffix,
 
     mc_suffix = suffix.replace('boot', 'reco_boot') if reco else suffix
 
-    def _glob(base_name):
+    def _glob(base_name, use_bootstrap=False):
+        bootstrap_string = "_boot" if use_bootstrap else ""
         pattern = os.path.join(
             data_folder,
-            f'{base_name}_unfolded_{niter}_{mc_suffix}_batch*.h5'
+            f'{base_name}_unfolded_niter_{niter}{bootstrap_string}_batch*.h5'
         )
         files = sorted(glob.glob(pattern))
         return files
 
     batch_files = {
-        'Rapgap':  _glob(f'Rapgap_{period}'),
+        'Rapgap':  _glob(f'Rapgap_{period}', use_bootstrap=bootstrap),
         'Djangoh': _glob(f'Djangoh_{period}'),
     }
 
@@ -84,7 +85,6 @@ def get_batch_files(data_folder, period, niter, suffix,
     if use_sys:
         for sys in sys_list:
             batch_files[sys] = _glob(f'{nominal}_{period}_{sys}')
-
     return batch_files
 
 

--- a/scripts/plot_utils.py
+++ b/scripts/plot_utils.py
@@ -217,15 +217,20 @@ def cluster_jets(dataloaders, n_workers=None):
         q = _calculate_q(cartesian, electron_momentum)
 
         n_events = cartesian.shape[0]
-        chunk_size = (n_events + n_workers - 1) // n_workers
+        print(f"[cluster_jets] {dataloader_name}: {n_events} events, {n_workers} workers", flush=True)
+
+        if n_events == 0:
+            data.all_jets = np.zeros((0, 4, 10), dtype=np.float32)
+            continue
+
+        effective_workers = min(n_workers, n_events)
+        chunk_size = (n_events + effective_workers - 1) // effective_workers
         chunks = [
             (cartesian[i:i + chunk_size], q[i:i + chunk_size])
             for i in range(0, n_events, chunk_size)
         ]
 
-        print(f"[cluster_jets] {dataloader_name}: {n_events} events, {n_workers} workers", flush=True)
-
-        with Pool(processes=n_workers) as pool:
+        with Pool(processes=effective_workers) as pool:
             results = pool.map(_cluster_chunk, chunks)
 
         data.all_jets = np.concatenate(results, axis=0).astype(np.float32)
@@ -1144,6 +1149,10 @@ def cluster_breit(flags, dataloaders):
     jetdef = fastjet.JetDefinition(fastjet.kt_algorithm, 1.0)
 
     for dataloader_name, data in dataloaders.items():
+        if data.event.shape[0] == 0:
+            dataloaders[dataloader_name].all_jets_breit = np.zeros((0, 4, 8), dtype=np.float32)
+            continue
+
         electron_momentum = _convert_electron_kinematics(data.event)
         cartesian = _convert_kinematics(data.part, data.event, data.mask)
         boosted_vectors = boost_particles(cartesian, electron_momentum)

--- a/scripts/plot_utils.py
+++ b/scripts/plot_utils.py
@@ -1,7 +1,8 @@
 import numpy as np
 import utils
 import awkward as ak
-
+import os
+from multiprocessing import Pool
 
 def _cluster_chunk(args):
     """Process a chunk of events for jet clustering (runs in a worker process)."""
@@ -128,85 +129,8 @@ def cluster_jets(dataloaders, n_workers=None):
         q_list = np.stack((q_x, q_y, q_z, q_E), axis=1)
         return q_list
 
-    def _calculate_jet_features(jet, q):
-        """Calculate jet features such as tau variables and ptD."""
-        tau_11, tau_11p5, tau_12, tau_20, sumpt = 0, 0, 0, 0, 0
-        for constituent in jet.constituents():
-            delta_r = jet.delta_R(constituent)
-            pt = constituent.pt()
 
-            tau_11 += pt * delta_r**1
-            tau_11p5 += pt * delta_r**1.5
-            tau_12 += pt * delta_r**2
-            tau_20 += pt**2
-            sumpt += pt
 
-        jet.tau_11 = np.log(tau_11 / jet.pt()) if jet.pt() > 0 else 0.0
-        jet.tau_11p5 = np.log(tau_11p5 / jet.pt()) if jet.pt() > 0 else 0.0
-        jet.tau_12 = np.log(tau_12 / jet.pt()) if jet.pt() > 0 else 0.0
-        jet.tau_20 = tau_20 / (jet.pt() ** 2) if jet.pt() > 0 else 0.0
-        jet.ptD = np.sqrt(tau_20) / sumpt if sumpt > 0 else 0.0
-
-        # Calculating zjet
-        P = np.array(
-            [0, 0, 920, 920], dtype=np.float32
-        )  # 920 GeV is proton beam energy
-        P_dot_q = P[3] * q[3] - P[0] * q[0] - P[1] * q[1] - P[2] * q[2]
-        z_jet_numerator = (
-            P[3] * jet.E() - P[0] * jet.px() - P[1] * jet.py() - P[2] * jet.pz()
-        )
-        jet.zjet = z_jet_numerator / P_dot_q
-
-    def _take_leading_jet(jets):
-        """Extract features of the leading jet."""
-        if not jets:
-            return np.zeros(10)
-
-        leading_jet = jets[0]
-        return np.array(
-            [
-                leading_jet.pt(),
-                leading_jet.eta(),
-                (leading_jet.phi() + np.pi) % (2 * np.pi) - np.pi,
-                leading_jet.E(),
-                leading_jet.tau_11,
-                leading_jet.tau_11p5,
-                leading_jet.tau_12,
-                leading_jet.tau_20,
-                leading_jet.ptD,
-                leading_jet.zjet,
-            ]
-        )
-
-    def _take_all_jets(jets):
-        max_num_jets = 4
-
-        if not jets:
-            return np.zeros((max_num_jets, 10))
-        jet_array = []
-        for i in range(max_num_jets):
-            if i < len(jets):
-                jet = jets[i]
-                jet_info = [
-                    jet.pt(),
-                    jet.eta(),
-                    (jet.phi() + np.pi) % (2 * np.pi) - np.pi,
-                    jet.E(),
-                    jet.tau_11,
-                    jet.tau_11p5,
-                    jet.tau_12,
-                    jet.tau_20,
-                    jet.ptD,
-                    jet.zjet,
-                ]
-            else:
-                jet_info = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-            jet_array.append(jet_info)
-
-        return np.array(jet_array)
-
-    import os
-    from multiprocessing import Pool
 
     if n_workers is None:
         n_workers = os.cpu_count() or 1
@@ -1206,13 +1130,6 @@ def cluster_breit(flags, dataloaders):
         jets["eta"] = np.arcsinh(jets["pz"] / jets["pt"])
         jets = fastjet.sorted_by_pt(jets)
 
-        # def _take_leading_jet(jets):
-        #     jet = np.zeros((data.event.shape[0],4))
-        #     jet[:,0] = -np.array(list(itertools.zip_longest(*jets.pt.to_list(), fillvalue=0))).T[:,0]
-        #     jet[:,1] = np.array(list(itertools.zip_longest(*jets.eta.to_list(), fillvalue=0))).T[:,0]
-        #     jet[:,2] = np.array(list(itertools.zip_longest(*jets.phi.to_list(), fillvalue=0))).T[:,0]
-        #     jet[:,3] = np.array(list(itertools.zip_longest(*jets.E.to_list(), fillvalue=0))).T[:,0]
-        #     return jet
 
         def _take_all_jets(jets, maxjets=5):
             jet = np.zeros((data.event.shape[0], maxjets, 7))
@@ -1239,27 +1156,7 @@ def cluster_breit(flags, dataloaders):
             ).T[:, :maxjets]
             return jet
 
-        # def _take_all_jets(jets, max_num_jets):
-        #     all_jets = []
-        #     for event in jets:
-        #         event_jets = []
-        #         for i in range(max_num_jets):
-        #             if i < len(event):
-        #                 jet_info = [-event[i].pt,
-        #                             event[i].eta,
-        #                             event[i].phi,
-        #                             event[i].E,
-        #                             event[i].px,
-        #                             event[i].py,
-        #                             event[i].pz
-        #                         ]
-        #             else:
-        #                 jet_info = [0, 0, 0, 0, 0, 0, 0]
-        #             event_jets.append(jet_info)
-        #         all_jets.append(event_jets)
-        #     return np.array(all_jets)
 
-        # dataloaders[dataloader_name].jet_breit = _take_leading_jet(jets)
 
         max_num_jets = 4
         dataloaders[dataloader_name].all_jets_breit = _take_all_jets(jets, max_num_jets)

--- a/scripts/plot_utils.py
+++ b/scripts/plot_utils.py
@@ -3,7 +3,62 @@ import utils
 import awkward as ak
 
 
-def cluster_jets(dataloaders):
+def _cluster_chunk(args):
+    """Process a chunk of events for jet clustering (runs in a worker process)."""
+    import fastjet
+    import numpy as np
+
+    cartesian_chunk, q_chunk = args
+    jetdef = fastjet.JetDefinition(fastjet.kt_algorithm, 1.0)
+
+    def _calculate_jet_features(jet, q):
+        tau_11, tau_11p5, tau_12, tau_20, sumpt = 0, 0, 0, 0, 0
+        for constituent in jet.constituents():
+            delta_r = jet.delta_R(constituent)
+            pt = constituent.pt()
+            tau_11 += pt * delta_r**1
+            tau_11p5 += pt * delta_r**1.5
+            tau_12 += pt * delta_r**2
+            tau_20 += pt**2
+            sumpt += pt
+        jet.tau_11 = np.log(tau_11 / jet.pt()) if jet.pt() > 0 else 0.0
+        jet.tau_11p5 = np.log(tau_11p5 / jet.pt()) if jet.pt() > 0 else 0.0
+        jet.tau_12 = np.log(tau_12 / jet.pt()) if jet.pt() > 0 else 0.0
+        jet.tau_20 = tau_20 / (jet.pt() ** 2) if jet.pt() > 0 else 0.0
+        jet.ptD = np.sqrt(tau_20) / sumpt if sumpt > 0 else 0.0
+        P = np.array([0, 0, 920, 920], dtype=np.float32)
+        P_dot_q = P[3] * q[3] - P[0] * q[0] - P[1] * q[1] - P[2] * q[2]
+        z_jet_numerator = P[3] * jet.E() - P[0] * jet.px() - P[1] * jet.py() - P[2] * jet.pz()
+        jet.zjet = z_jet_numerator / P_dot_q
+
+    def _take_all_jets(jets):
+        max_num_jets = 4
+        if not jets:
+            return np.zeros((max_num_jets, 10))
+        jet_array = []
+        for i in range(max_num_jets):
+            if i < len(jets):
+                jet = jets[i]
+                jet_info = [jet.pt(), jet.eta(), (jet.phi() + np.pi) % (2 * np.pi) - np.pi,
+                            jet.E(), jet.tau_11, jet.tau_11p5, jet.tau_12, jet.tau_20, jet.ptD, jet.zjet]
+            else:
+                jet_info = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+            jet_array.append(jet_info)
+        return np.array(jet_array)
+
+    list_of_all_jets = []
+    for i, event in enumerate(cartesian_chunk):
+        particles = [fastjet.PseudoJet(p[0], p[1], p[2], p[3]) for p in event if np.abs(p[0]) != 0]
+        cluster = fastjet.ClusterSequence(particles, jetdef)
+        sorted_jets = fastjet.sorted_by_pt(cluster.inclusive_jets(ptmin=10))
+        for jet in sorted_jets:
+            _calculate_jet_features(jet, q_chunk[i])
+        list_of_all_jets.append(_take_all_jets(sorted_jets))
+
+    return np.array(list_of_all_jets, dtype=np.float32)
+
+
+def cluster_jets(dataloaders, n_workers=None):
     """
     Update dataloaders with clustered jet information.
 
@@ -150,39 +205,30 @@ def cluster_jets(dataloaders):
 
         return np.array(jet_array)
 
-    for dataloader_name, data in dataloaders.items():
-        # print(f"----------------- Started working with {dataloader_name} -------------------")
+    import os
+    from multiprocessing import Pool
 
-        # Convert particles to Cartesian coordinates
+    if n_workers is None:
+        n_workers = os.cpu_count() or 1
+
+    for dataloader_name, data in dataloaders.items():
         cartesian = _convert_kinematics(data.part, data.event, data.mask)
         electron_momentum = _convert_electron_kinematics(data.event)
-        # print(cartesian)
         q = _calculate_q(cartesian, electron_momentum)
-        list_of_jets = []
-        list_of_all_jets = []
-        for i, event in enumerate(cartesian):
-            particles = [
-                fastjet.PseudoJet(p[0], p[1], p[2], p[3])
-                for p in event
-                if np.abs(p[0]) != 0
-            ]
 
-            # Cluster jets and sort by pt
-            cluster = fastjet.ClusterSequence(particles, jetdef)
-            sorted_jets = fastjet.sorted_by_pt(cluster.inclusive_jets(ptmin=10))
-            # Calculate jet features
-            for jet in sorted_jets:
-                _calculate_jet_features(jet, q[i])
+        n_events = cartesian.shape[0]
+        chunk_size = (n_events + n_workers - 1) // n_workers
+        chunks = [
+            (cartesian[i:i + chunk_size], q[i:i + chunk_size])
+            for i in range(0, n_events, chunk_size)
+        ]
 
-            # Take the leading jet's features
-            # leading_jet = _take_leading_jet(sorted_jets)
-            # list_of_jets.append(leading_jet)
-            all_jets = _take_all_jets(sorted_jets)
-            list_of_all_jets.append(all_jets)
-        # Store the jet features in the dataloader
-        # data.jet = np.array(list_of_jets, dtype=np.float32)
-        data.all_jets = np.array(list_of_all_jets, dtype=np.float32)
-        # print(f"----------------- Done working with {dataloader_name} -------------------")
+        print(f"[cluster_jets] {dataloader_name}: {n_events} events, {n_workers} workers", flush=True)
+
+        with Pool(processes=n_workers) as pool:
+            results = pool.map(_cluster_chunk, chunks)
+
+        data.all_jets = np.concatenate(results, axis=0).astype(np.float32)
 
 
 def plot_particles(flags, dataloaders, data_weights, version, num_part, nbins=10):
@@ -1355,7 +1401,7 @@ def plot_observable(flags, var, dataloaders, version):
         return ak.to_numpy(counts), bins
 
     # Determine weight name
-    weight_name = "closure_weights" if flags.blind else "weights"
+    weight_name = "closure_weights" if flags.blind else "weights1"
     if flags.blind:
         data_name = "Rapgap_closure"
     elif flags.reco:

--- a/scripts/save_unfolded_weights.py
+++ b/scripts/save_unfolded_weights.py
@@ -93,8 +93,9 @@ def get_dataloaders_batch(flags, file_names, batch_start, batch_end):
                 is_mc=False,
                 rank=0,
                 size=1,
-                nmax=batch_end,
+                nmax=flags.nmax,
                 global_start=batch_start,
+                global_end = batch_end,
                 pass_reco=True,
             )
         else:
@@ -104,8 +105,9 @@ def get_dataloaders_batch(flags, file_names, batch_start, batch_end):
                 is_mc=True,
                 rank=0,
                 size=1,
-                nmax=batch_end,
+                nmax=flags.nmax,
                 global_start=batch_start,
+                global_end = batch_end,
                 pass_fiducial=not flags.reco,
                 pass_reco=flags.reco,
             )

--- a/scripts/save_unfolded_weights.py
+++ b/scripts/save_unfolded_weights.py
@@ -242,7 +242,7 @@ def main():
 
     print(f"[rank {hvd.rank()}] total_events={total_events}, num_batches={num_batches}, hvd.size()={hvd.size()}", flush=True)
 
-    replace_string = f"unfolded_{flags.niter}_centauro"
+    replace_string = f"unfolded_{flags.niter}"
     if flags.reco:
         replace_string += "_reco"
     if flags.bootstrap:

--- a/scripts/save_unfolded_weights.py
+++ b/scripts/save_unfolded_weights.py
@@ -34,7 +34,7 @@ def parse_arguments():
         help="Basic config file containing general options",
     )
     parser.add_argument(
-        "--reco", action="store_true", default=False, help="Plot reco level  results"
+        "--reco", action="store_true", default=False, help="Plot reco level results"
     )
     parser.add_argument(
         "--file", default="Rapgap_Eplus0607_prep.h5", help="File to load"
@@ -71,8 +71,8 @@ def parse_arguments():
     return flags
 
 
-def get_dataloaders_limited(flags, file_names, nmax_override):
-    """Load data with a specific nmax limit"""
+def get_dataloaders_batch(flags, file_names, batch_start, batch_end):
+    """Load a batch window [batch_start, batch_end) entirely on this rank"""
     dataloaders = {}
 
     for name in file_names:
@@ -81,9 +81,10 @@ def get_dataloaders_limited(flags, file_names, nmax_override):
                 [name],
                 flags.data_folder,
                 is_mc=False,
-                rank=hvd.rank(),
-                size=hvd.size(),
-                nmax=None,
+                rank=0,
+                size=1,
+                nmax=batch_end,
+                global_start=batch_start,
                 pass_reco=True,
             )
         else:
@@ -91,9 +92,10 @@ def get_dataloaders_limited(flags, file_names, nmax_override):
                 [name],
                 flags.data_folder,
                 is_mc=True,
-                rank=hvd.rank(),
-                size=hvd.size(),
-                nmax=nmax_override,
+                rank=0,
+                size=1,
+                nmax=batch_end,
+                global_start=batch_start,
                 pass_fiducial=not flags.reco,
                 pass_reco=flags.reco,
             )
@@ -110,114 +112,94 @@ def get_deltaphi(jet, elec):
 def load_weights_slice(flags, global_start, global_end):
     """Load a slice of weights from the HDF5 file"""
     weights = {}
-    
+
     if "data" not in flags.file:
-        with h5.File(flags.data_folder + flags.pre_weights_file, "r") as fh5:
+        print(f"[rank {hvd.rank()}] load_weights_slice: opening weights file", flush=True)
+        with h5.File(os.path.join(flags.data_folder, flags.pre_weights_file), "r") as fh5:
             total_size = fh5["reco_event_features"].shape[0]
-            
-            per_rank = (global_end - global_start + hvd.size() - 1) // hvd.size()
-            rank_start = global_start + hvd.rank() * per_rank
-            rank_end = min(rank_start + per_rank, global_end, total_size)
-            
-            if rank_start >= rank_end:
-                return {}
-            
-            pass_gen = fh5["gen_event_features"][rank_start:rank_end, -1] == 1
-            pass_reco = fh5["reco_event_features"][rank_start:rank_end, -1] == 1
-            
+            start = global_start
+            end = min(global_end, total_size)
+
+            print(f"[rank {hvd.rank()}] load_weights_slice: reading [{start}, {end})", flush=True)
+
+            pass_gen = fh5["gen_event_features"][start:end, -1] == 1
+            pass_reco = fh5["reco_event_features"][start:end, -1] == 1
+
             if not flags.reco:
-                combined_mask = pass_gen 
+                combined_mask = pass_gen
             else:
                 combined_mask = pass_reco
-            
+
             if "unfolded_weights" in fh5:
-                weights[flags.file] = fh5["unfolded_weights"][rank_start:rank_end][combined_mask]
+                weights[flags.file] = fh5["unfolded_weights"][start:end][combined_mask]
             else:
                 raise KeyError("File has no dataset 'unfolded_weights'")
-            
+
             if flags.bootstrap:
                 for i in range(1, flags.nboot + 1):
                     key = f"unfolded_weights_boots{i}"
                     if key in fh5:
-                        weights[str(i)] = fh5[key][rank_start:rank_end][combined_mask]
+                        weights[str(i)] = fh5[key][start:end][combined_mask]
                     else:
-                        if hvd.rank() == 0:
-                            print(f"Warning: bootstrap key {key} not found, skipping")
-            
+                        print(f"[rank {hvd.rank()}] Warning: bootstrap key {key} not found, skipping")
+
             if "unfolded_weights_closure" in fh5:
-                weights["closure"] = fh5["unfolded_weights_closure"][rank_start:rank_end][combined_mask]
-    
+                weights["closure"] = fh5["unfolded_weights_closure"][start:end][combined_mask]
+
+        print(f"[rank {hvd.rank()}] load_weights_slice: done", flush=True)
+
     return weights
 
 
-def process_batch(flags, batch_nmax_end, weights_dict, opt, global_batch_idx, events_processed_so_far):
-    """Process a single batch by loading data with nmax limit"""
-    
-    if hvd.rank() == 0 and flags.verbose:
-        print(f"Loading batch data with nmax={batch_nmax_end}...")
-    
+def process_batch(flags, batch_start, batch_end, weights_dict, opt):
+    """Load and process events in [batch_start, batch_end) split across ranks"""
+
+    print(f"[rank {hvd.rank()}] process_batch: loading data [{batch_start}, {batch_end})", flush=True)
+
     mc_files = [flags.file]
-    dataloaders = get_dataloaders_limited(flags, mc_files, batch_nmax_end)
-    
-    if hvd.rank() == 0 and flags.verbose:
-        print(f"Processing batch (standardization, clustering)...")
-    
+    dataloaders = get_dataloaders_batch(flags, mc_files, batch_start, batch_end)
+
+    print(f"[rank {hvd.rank()}] process_batch: undo_standardizing", flush=True)
     undo_standardizing(flags, dataloaders)
-    cluster_jets(dataloaders)
+    print(f"[rank {hvd.rank()}] process_batch: cluster_jets", flush=True)
+    cluster_jets(dataloaders, n_workers=int(os.environ.get("SLURM_CPUS_PER_TASK", 1)))
+    print(f"[rank {hvd.rank()}] process_batch: cluster_breit", flush=True)
     cluster_breit(flags, dataloaders)
-    
+
     del dataloaders[flags.file].part, dataloaders[flags.file].mask
     gc.collect()
-    
+
     dataset = dataloaders[flags.file]
-    
-    # Calculate how many events this rank has in the current dataset
-    num_events_this_rank = dataset.all_jets.shape[0]
-    
-    # Skip events that were already processed in previous batches
-    if events_processed_so_far < num_events_this_rank:
-        start_idx = events_processed_so_far
-        
-        results = {
-            'jet_pt': dataset.all_jets[start_idx:, :, 0],
-            'jet_breit_pt': dataset.all_jets_breit[start_idx:, :, 0],
-            'deltaphi': get_deltaphi(dataset.all_jets[start_idx:], dataset.event[start_idx:]),
-            'jet_tau10': dataset.all_jets[start_idx:, :, 4],
-            'zjet': dataset.all_jets[start_idx:, :, 9],
-            'zjet_breit': dataset.all_jets_breit[start_idx:, :, 7],
-        }
-        
-        if "data" not in flags.file:
-            results['mc_weights'] = dataset.weight[start_idx:]
-            results['weights'] = weights_dict
-    else:
-        # This rank has no new events for this batch
-        results = {
-            'jet_pt': np.array([]).reshape(0, dataset.all_jets.shape[1], 0),
-            'jet_breit_pt': np.array([]).reshape(0, dataset.all_jets_breit.shape[1], 0),
-            'deltaphi': np.array([]).reshape(0, dataset.all_jets.shape[1]),
-            'jet_tau10': np.array([]).reshape(0, dataset.all_jets.shape[1], 0),
-            'zjet': np.array([]).reshape(0, dataset.all_jets.shape[1], 0),
-            'zjet_breit': np.array([]).reshape(0, dataset.all_jets_breit.shape[1], 0),
-        }
-        
-        if "data" not in flags.file:
-            results['mc_weights'] = np.array([])
-            results['weights'] = weights_dict
-    
-    # Clean up dataloaders
+
+    print(f"[rank {hvd.rank()}] process_batch: extracting results ({dataset.all_jets.shape[0]} events)", flush=True)
+    results = {
+        'jet_pt': dataset.all_jets[:, :, 0],
+        'jet_breit_pt': dataset.all_jets_breit[:, :, 0],
+        'deltaphi': get_deltaphi(dataset.all_jets, dataset.event),
+        'jet_tau10': dataset.all_jets[:, :, 4],
+        'zjet': dataset.all_jets[:, :, 9],
+        'zjet_breit': dataset.all_jets_breit[:, :, 7],
+    }
+
+    if "data" not in flags.file:
+        results['mc_weights'] = dataset.weight
+        results['weights'] = weights_dict
+
     del dataloaders
     gc.collect()
-    
-    return results, num_events_this_rank
+
+    print(f"[rank {hvd.rank()}] process_batch: done", flush=True)
+    return results
 
 
 def gather_results_across_ranks(results):
     """Gather results from all ranks to rank 0"""
     gathered = {}
-    
+
+    print(f"[rank {hvd.rank()}] gather: starting allgather", flush=True)
     # Gather each array separately
     for key in results.keys():
+        print(f"[rank {hvd.rank()}] gather: allgather key='{key}'", flush=True)
         if key == 'weights':
             # Handle nested weights dictionary
             gathered[key] = {}
@@ -225,7 +207,8 @@ def gather_results_across_ranks(results):
                 gathered[key][weight_key] = hvd.allgather_object(results[key][weight_key])
         else:
             gathered[key] = hvd.allgather_object(results[key])
-    
+
+    print(f"[rank {hvd.rank()}] gather: allgather complete", flush=True)
     # Only rank 0 concatenates the results
     if hvd.rank() == 0:
         concatenated = {}
@@ -242,6 +225,7 @@ def gather_results_across_ranks(results):
                 valid_arrays = [arr for arr in gathered[key] if arr is not None and len(arr) > 0]
                 if valid_arrays:
                     concatenated[key] = np.concatenate(valid_arrays, axis=0)
+        print(f"[rank 0] gather: concatenation complete", flush=True)
         return concatenated
     else:
         return None
@@ -251,110 +235,75 @@ def main():
     utils.setup_gpus(hvd.local_rank())
     flags = parse_arguments()
     opt = utils.LoadJson(flags.config)
-    
-    # Calculate batch parameters
+
     total_events = flags.nmax
     batch_size = flags.batch_size
     num_batches = (total_events + batch_size - 1) // batch_size
-    
-    if hvd.rank() == 0:
-        print(f"Total events to process: {total_events}")
-        print(f"Batch size: {batch_size}")
-        print(f"Number of batches: {num_batches}")
-        print(f"Processing with {hvd.size()} MPI ranks")
-    
-    # Initialize output file base name
+
+    print(f"[rank {hvd.rank()}] total_events={total_events}, num_batches={num_batches}, hvd.size()={hvd.size()}", flush=True)
+
     replace_string = f"unfolded_{flags.niter}_centauro"
     if flags.reco:
         replace_string += "_reco"
     if flags.bootstrap:
         replace_string += "_boot"
-    
-    # Process data in batches
-    output_files = []
-    events_processed_so_far = 0  # Track events already processed by this rank
-    
-    for batch_idx in range(num_batches):
-        batch_start = batch_idx * batch_size
-        batch_end = min(batch_start + batch_size, total_events)
-        
-        if hvd.rank() == 0:
-            print(f"\n{'='*60}")
-            print(f"Processing batch {batch_idx + 1}/{num_batches}")
-            print(f"Global events: {batch_start} to {batch_end}")
-            print(f"{'='*60}")
-        
-        # Load weights for this batch slice
-        if "data" not in flags.file:
-            weights_dict = load_weights_slice(flags, batch_start, batch_end)
-        else:
-            weights_dict = {}
-        
-        batch_results, num_events_loaded = process_batch(
-            flags, batch_end, weights_dict, opt, batch_idx, events_processed_so_far
-        )
-        
-        events_processed_so_far = num_events_loaded
-        
-        if hvd.rank() == 0 and flags.verbose:
-            print(f"Gathering results from all ranks...")
-        
-        aggregated_results = gather_results_across_ranks(batch_results)
-        
-        del batch_results, weights_dict
-        gc.collect()
-        
-        if hvd.rank() == 0:
-            base_name = flags.file.replace("prep.h5", "")
-            output_file_name = f"{base_name}{replace_string}_batch{batch_idx:04d}.h5"
-            output_path = os.path.join(flags.data_folder, output_file_name)
-            output_files.append(output_file_name)
-            
-            with h5.File(output_path, 'w') as fh5:
-                
-                if "data" not in flags.file and 'weights' in aggregated_results and len(aggregated_results['weights']) > 0:
-                    if flags.bootstrap:
-                        for i in range(1, flags.nboot):
-                            if str(i) in aggregated_results['weights']:
-                                fh5.create_dataset(
-                                    f"weights{i}", 
-                                    data=aggregated_results['weights'][str(i)]
-                                )
-                    else:
-                        if flags.file in aggregated_results['weights']:
-                            fh5.create_dataset(
-                                "weights", 
-                                data=aggregated_results['weights'][flags.file]
-                            )
-                    
-                    if 'mc_weights' in aggregated_results:
-                        fh5.create_dataset(
-                            "mc_weights", 
-                            data=aggregated_results['mc_weights']
-                        )
-                    
-                    if "closure" in aggregated_results['weights']:
-                        fh5.create_dataset(
-                            "closure_weights", 
-                            data=aggregated_results['weights']["closure"]
-                        )
-                
-                # Write jet features
-                fh5.create_dataset("jet_pt", data=aggregated_results['jet_pt'])
-                fh5.create_dataset("jet_breit_pt", data=aggregated_results['jet_breit_pt'])
-                fh5.create_dataset("deltaphi", data=aggregated_results['deltaphi'])
-                fh5.create_dataset("jet_tau10", data=aggregated_results['jet_tau10'])
-                fh5.create_dataset("zjet", data=aggregated_results['zjet'])
-                fh5.create_dataset("zjet_breit", data=aggregated_results['zjet_breit'])
-            
-            print(f"Saved aggregated batch {batch_idx + 1} to: {output_file_name}")
-            if flags.verbose:
-                print(f"  File contains data from {hvd.size()} ranks")
-        
-        # Clean up aggregated results
-        if hvd.rank() == 0:
-            del aggregated_results
-            gc.collect()
+
+    # Each rank independently processes the batch assigned to it.
+    # Ranks with index >= num_batches have nothing to do.
+    batch_idx = hvd.rank()
+    if batch_idx >= num_batches:
+        print(f"[rank {hvd.rank()}] no batch to process, exiting", flush=True)
+        return
+
+    batch_start = batch_idx * batch_size
+    batch_end = min(batch_start + batch_size, total_events)
+
+    print(f"[rank {hvd.rank()}] processing batch {batch_idx} events [{batch_start}, {batch_end})", flush=True)
+
+    if "data" not in flags.file:
+        weights_dict = load_weights_slice(flags, batch_start, batch_end)
+    else:
+        weights_dict = {}
+
+    # Load the full batch on this rank (size=1, rank=0 within the batch)
+    results = process_batch(flags, batch_start, batch_end, weights_dict, opt)
+
+    base_name = flags.file.replace("prep.h5", "")
+    output_file_name = f"{base_name}{replace_string}_batch{batch_idx:04d}.h5"
+    output_path = os.path.join(flags.data_folder, output_file_name)
+
+    if os.path.exists(output_path):
+        os.remove(output_path)
+
+    with h5.File(output_path, 'w') as fh5:
+        if "data" not in flags.file and 'weights' in results and len(results['weights']) > 0:
+            if flags.file in results['weights']:
+                fh5.create_dataset("weights_nominal", data=results['weights'][flags.file])
+            if flags.bootstrap:
+                for i in range(1, flags.nboot):
+                    if str(i) in results['weights']:
+                        fh5.create_dataset(f"weights{i}", data=results['weights'][str(i)])
+            else:
+                if flags.file in results['weights']:
+                    fh5.create_dataset("weights", data=results['weights'][flags.file])
+
+            if 'mc_weights' in results:
+                fh5.create_dataset("mc_weights", data=results['mc_weights'])
+
+            if "closure" in results['weights']:
+                fh5.create_dataset("closure_weights", data=results['weights']["closure"])
+
+        fh5.create_dataset("jet_pt", data=results['jet_pt'])
+        fh5.create_dataset("jet_breit_pt", data=results['jet_breit_pt'])
+        fh5.create_dataset("deltaphi", data=results['deltaphi'])
+        fh5.create_dataset("jet_tau10", data=results['jet_tau10'])
+        fh5.create_dataset("zjet", data=results['zjet'])
+        fh5.create_dataset("zjet_breit", data=results['zjet_breit'])
+
+    n_entries = results['jet_pt'].shape[0]
+    print(f"[rank {hvd.rank()}] saved batch {batch_idx} to {output_file_name} ({n_entries:,} entries)", flush=True)
+    del results, weights_dict
+    gc.collect()
     
 
 if __name__ == "__main__":

--- a/scripts/save_unfolded_weights.py
+++ b/scripts/save_unfolded_weights.py
@@ -20,6 +20,11 @@ def parse_arguments():
         help="Folder containing data and MC files",
     )
     parser.add_argument(
+        "--output_folder",
+        default="/pscratch/sd/t/twamorka/h1/batchfiles/",
+        help="",
+    )
+    parser.add_argument(
         "--weights", default="../weights", help="Folder to store trained weights"
     )
     parser.add_argument(
@@ -36,9 +41,9 @@ def parse_arguments():
     parser.add_argument(
         "--reco", action="store_true", default=False, help="Plot reco level results"
     )
-    parser.add_argument(
-        "--file", default="Rapgap_Eplus0607_prep.h5", help="File to load"
-    )
+    # parser.add_argument(
+    #     "--file", default="Rapgap_Eplus0607_prep.h5", help="File to load"
+    # )
     parser.add_argument(
         "--niter", type=int, default=4, help="Omnifold iteration to load"
     )
@@ -54,8 +59,13 @@ def parse_arguments():
         default=False,
         help="Load models for bootstrapping",
     )
+    # parser.add_argument(
+    #     "--pre_weights_file",
+    #     default=None,
+    #     help="Path to HDF5 file containing pre-evaluated weights",
+    # )
     parser.add_argument(
-        "--pre_weights_file",
+        "--file",
         default=None,
         help="Path to HDF5 file containing pre-evaluated weights",
     )
@@ -115,7 +125,7 @@ def load_weights_slice(flags, global_start, global_end):
 
     if "data" not in flags.file:
         print(f"[rank {hvd.rank()}] load_weights_slice: opening weights file", flush=True)
-        with h5.File(os.path.join(flags.data_folder, flags.pre_weights_file), "r") as fh5:
+        with h5.File(os.path.join(flags.data_folder, flags.file), "r") as fh5:
             total_size = fh5["reco_event_features"].shape[0]
             start = global_start
             end = min(global_end, total_size)
@@ -135,7 +145,7 @@ def load_weights_slice(flags, global_start, global_end):
             else:
                 raise KeyError("File has no dataset 'unfolded_weights'")
 
-            if flags.bootstrap:
+            if flags.bootstrap and "Rapgap" in flags.file:
                 for i in range(1, flags.nboot + 1):
                     key = f"unfolded_weights_boots{i}"
                     if key in fh5:
@@ -192,43 +202,6 @@ def process_batch(flags, batch_start, batch_end, weights_dict, opt):
     return results
 
 
-def gather_results_across_ranks(results):
-    """Gather results from all ranks to rank 0"""
-    gathered = {}
-
-    print(f"[rank {hvd.rank()}] gather: starting allgather", flush=True)
-    # Gather each array separately
-    for key in results.keys():
-        print(f"[rank {hvd.rank()}] gather: allgather key='{key}'", flush=True)
-        if key == 'weights':
-            # Handle nested weights dictionary
-            gathered[key] = {}
-            for weight_key in results[key].keys():
-                gathered[key][weight_key] = hvd.allgather_object(results[key][weight_key])
-        else:
-            gathered[key] = hvd.allgather_object(results[key])
-
-    print(f"[rank {hvd.rank()}] gather: allgather complete", flush=True)
-    # Only rank 0 concatenates the results
-    if hvd.rank() == 0:
-        concatenated = {}
-        for key in gathered.keys():
-            if key == 'weights':
-                concatenated[key] = {}
-                for weight_key in gathered[key].keys():
-                    # Filter out None/empty arrays and concatenate
-                    valid_arrays = [arr for arr in gathered[key][weight_key] if arr is not None and len(arr) > 0]
-                    if valid_arrays:
-                        concatenated[key][weight_key] = np.concatenate(valid_arrays, axis=0)
-            else:
-                # Filter out None/empty arrays and concatenate
-                valid_arrays = [arr for arr in gathered[key] if arr is not None and len(arr) > 0]
-                if valid_arrays:
-                    concatenated[key] = np.concatenate(valid_arrays, axis=0)
-        print(f"[rank 0] gather: concatenation complete", flush=True)
-        return concatenated
-    else:
-        return None
 
 
 def main():
@@ -242,7 +215,7 @@ def main():
 
     print(f"[rank {hvd.rank()}] total_events={total_events}, num_batches={num_batches}, hvd.size()={hvd.size()}", flush=True)
 
-    replace_string = f"unfolded_{flags.niter}"
+    replace_string = f"unfolded_niter_{flags.niter}"
     if flags.reco:
         replace_string += "_reco"
     if flags.bootstrap:
@@ -268,9 +241,10 @@ def main():
     # Load the full batch on this rank (size=1, rank=0 within the batch)
     results = process_batch(flags, batch_start, batch_end, weights_dict, opt)
 
-    base_name = flags.file.replace("prep.h5", "")
+    stem = os.path.splitext(flags.file)[0]
+    base_name = stem.split("_unfolded")[0].removesuffix("_prep") + "_"
     output_file_name = f"{base_name}{replace_string}_batch{batch_idx:04d}.h5"
-    output_path = os.path.join(flags.data_folder, output_file_name)
+    output_path = os.path.join(flags.output_folder, output_file_name)
 
     if os.path.exists(output_path):
         os.remove(output_path)
@@ -279,7 +253,7 @@ def main():
         if "data" not in flags.file and 'weights' in results and len(results['weights']) > 0:
             if flags.file in results['weights']:
                 fh5.create_dataset("weights_nominal", data=results['weights'][flags.file])
-            if flags.bootstrap:
+            if flags.bootstrap and "Rapgap" in flags.file:
                 for i in range(1, flags.nboot):
                     if str(i) in results['weights']:
                         fh5.create_dataset(f"weights{i}", data=results['weights'][str(i)])

--- a/scripts/save_unfolded_weights.py
+++ b/scripts/save_unfolded_weights.py
@@ -223,63 +223,58 @@ def main():
     if flags.bootstrap and "Rapgap" in flags.file:
         replace_string += "_boot"
 
-    # Each rank independently processes the batch assigned to it.
-    # Ranks with index >= num_batches have nothing to do.
-    batch_idx = hvd.rank()
-    if batch_idx >= num_batches:
-        print(f"[rank {hvd.rank()}] no batch to process, exiting", flush=True)
-        return
-
-    batch_start = batch_idx * batch_size
-    batch_end = min(batch_start + batch_size, total_events)
-
-    print(f"[rank {hvd.rank()}] processing batch {batch_idx} events [{batch_start}, {batch_end})", flush=True)
-
-    if "data" not in flags.file:
-        weights_dict = load_weights_slice(flags, batch_start, batch_end)
-    else:
-        weights_dict = {}
-
-    # Load the full batch on this rank (size=1, rank=0 within the batch)
-    results = process_batch(flags, batch_start, batch_end, weights_dict, opt)
-
     stem = os.path.splitext(flags.file)[0]
     base_name = stem.split("_unfolded")[0].removesuffix("_prep") + "_"
-    output_file_name = f"{base_name}{replace_string}_batch{batch_idx:04d}.h5"
-    output_path = os.path.join(flags.output_folder, output_file_name)
 
-    if os.path.exists(output_path):
-        os.remove(output_path)
+    # Strided round-robin: rank r handles batches r, r+size, r+2*size, ...
+    for batch_idx in range(hvd.rank(), num_batches, hvd.size()):
+        batch_start = batch_idx * batch_size
+        batch_end = min(batch_start + batch_size, total_events)
 
-    with h5.File(output_path, 'w') as fh5:
-        if "data" not in flags.file and 'weights' in results and len(results['weights']) > 0:
-            if flags.file in results['weights']:
-                fh5.create_dataset("weights_nominal", data=results['weights'][flags.file])
-            if flags.bootstrap and "Rapgap" in flags.file:
-                for i in range(1, flags.nboot):
-                    if str(i) in results['weights']:
-                        fh5.create_dataset(f"weights{i}", data=results['weights'][str(i)])
-            else:
+        print(f"[rank {hvd.rank()}] processing batch {batch_idx} events [{batch_start}, {batch_end})", flush=True)
+
+        if "data" not in flags.file:
+            weights_dict = load_weights_slice(flags, batch_start, batch_end)
+        else:
+            weights_dict = {}
+
+        results = process_batch(flags, batch_start, batch_end, weights_dict, opt)
+
+        output_file_name = f"{base_name}{replace_string}_batch{batch_idx:04d}.h5"
+        output_path = os.path.join(flags.output_folder, output_file_name)
+
+        if os.path.exists(output_path):
+            os.remove(output_path)
+
+        with h5.File(output_path, 'w') as fh5:
+            if "data" not in flags.file and 'weights' in results and len(results['weights']) > 0:
                 if flags.file in results['weights']:
-                    fh5.create_dataset("weights", data=results['weights'][flags.file])
+                    fh5.create_dataset("weights_nominal", data=results['weights'][flags.file])
+                if flags.bootstrap and "Rapgap" in flags.file:
+                    for i in range(1, flags.nboot):
+                        if str(i) in results['weights']:
+                            fh5.create_dataset(f"weights{i}", data=results['weights'][str(i)])
+                else:
+                    if flags.file in results['weights']:
+                        fh5.create_dataset("weights", data=results['weights'][flags.file])
 
-            if 'mc_weights' in results:
-                fh5.create_dataset("mc_weights", data=results['mc_weights'])
+                if 'mc_weights' in results:
+                    fh5.create_dataset("mc_weights", data=results['mc_weights'])
 
-            if "closure" in results['weights']:
-                fh5.create_dataset("closure_weights", data=results['weights']["closure"])
+                if "closure" in results['weights']:
+                    fh5.create_dataset("closure_weights", data=results['weights']["closure"])
 
-        fh5.create_dataset("jet_pt", data=results['jet_pt'])
-        fh5.create_dataset("jet_breit_pt", data=results['jet_breit_pt'])
-        fh5.create_dataset("deltaphi", data=results['deltaphi'])
-        fh5.create_dataset("jet_tau10", data=results['jet_tau10'])
-        fh5.create_dataset("zjet", data=results['zjet'])
-        fh5.create_dataset("zjet_breit", data=results['zjet_breit'])
+            fh5.create_dataset("jet_pt", data=results['jet_pt'])
+            fh5.create_dataset("jet_breit_pt", data=results['jet_breit_pt'])
+            fh5.create_dataset("deltaphi", data=results['deltaphi'])
+            fh5.create_dataset("jet_tau10", data=results['jet_tau10'])
+            fh5.create_dataset("zjet", data=results['zjet'])
+            fh5.create_dataset("zjet_breit", data=results['zjet_breit'])
 
-    n_entries = results['jet_pt'].shape[0]
-    print(f"[rank {hvd.rank()}] saved batch {batch_idx} to {output_file_name} ({n_entries:,} entries)", flush=True)
-    del results, weights_dict
-    gc.collect()
+        n_entries = results['jet_pt'].shape[0]
+        print(f"[rank {hvd.rank()}] saved batch {batch_idx} to {output_file_name} ({n_entries:,} entries)", flush=True)
+        del results, weights_dict
+        gc.collect()
     
 
 if __name__ == "__main__":

--- a/scripts/save_unfolded_weights.py
+++ b/scripts/save_unfolded_weights.py
@@ -21,7 +21,7 @@ def parse_arguments():
     )
     parser.add_argument(
         "--output_folder",
-        default="/pscratch/sd/t/twamorka/h1/batchfiles/",
+        default="/global/cfs/cdirs/m3246/rmilton/tanvi_batching/test_data/",
         help="",
     )
     parser.add_argument(
@@ -175,8 +175,8 @@ def process_batch(flags, batch_start, batch_end, weights_dict, opt):
     undo_standardizing(flags, dataloaders)
     print(f"[rank {hvd.rank()}] process_batch: cluster_jets", flush=True)
     cluster_jets(dataloaders, n_workers=int(os.environ.get("SLURM_CPUS_PER_TASK", 1)))
-    print(f"[rank {hvd.rank()}] process_batch: cluster_breit", flush=True)
-    cluster_breit(flags, dataloaders)
+    # print(f"[rank {hvd.rank()}] process_batch: cluster_breit", flush=True)
+    # cluster_breit(flags, dataloaders)
 
     del dataloaders[flags.file].part, dataloaders[flags.file].mask
     gc.collect()
@@ -186,11 +186,11 @@ def process_batch(flags, batch_start, batch_end, weights_dict, opt):
     print(f"[rank {hvd.rank()}] process_batch: extracting results ({dataset.all_jets.shape[0]} events)", flush=True)
     results = {
         'jet_pt': dataset.all_jets[:, :, 0],
-        'jet_breit_pt': dataset.all_jets_breit[:, :, 0],
-        'deltaphi': get_deltaphi(dataset.all_jets, dataset.event),
-        'jet_tau10': dataset.all_jets[:, :, 4],
-        'zjet': dataset.all_jets[:, :, 9],
-        'zjet_breit': dataset.all_jets_breit[:, :, 7],
+        # 'jet_breit_pt': dataset.all_jets_breit[:, :, 0],
+        # 'deltaphi': get_deltaphi(dataset.all_jets, dataset.event),
+        # 'jet_tau10': dataset.all_jets[:, :, 4],
+        # 'zjet': dataset.all_jets[:, :, 9],
+        # 'zjet_breit': dataset.all_jets_breit[:, :, 7],
     }
 
     if "data" not in flags.file:
@@ -225,15 +225,15 @@ def main():
 
     # Each rank independently processes the batch assigned to it.
     # Ranks with index >= num_batches have nothing to do.
-    batch_idx = hvd.rank()
-    if batch_idx >= num_batches:
-        print(f"[rank {hvd.rank()}] no batch to process, exiting", flush=True)
-        return
+    for batch_idx in range(hvd.rank(), num_batches, hvd.size()):
+        batch_start = batch_idx * batch_size
+        batch_end = min(batch_start + batch_size, total_events)
 
-    batch_start = batch_idx * batch_size
-    batch_end = min(batch_start + batch_size, total_events)
-
-    print(f"[rank {hvd.rank()}] processing batch {batch_idx} events [{batch_start}, {batch_end})", flush=True)
+        print(
+            f"[rank {hvd.rank()}] processing batch {batch_idx} "
+            f"events [{batch_start}, {batch_end})",
+            flush=True,
+        )
 
     if "data" not in flags.file:
         weights_dict = load_weights_slice(flags, batch_start, batch_end)
@@ -276,10 +276,17 @@ def main():
         fh5.create_dataset("zjet", data=results['zjet'])
         fh5.create_dataset("zjet_breit", data=results['zjet_breit'])
 
-    n_entries = results['jet_pt'].shape[0]
-    print(f"[rank {hvd.rank()}] saved batch {batch_idx} to {output_file_name} ({n_entries:,} entries)", flush=True)
-    del results, weights_dict
-    gc.collect()
+        n_entries = results["jet_pt"].shape[0]
+        print(
+            f"[rank {hvd.rank()}] saved batch {batch_idx} "
+            f"to {output_file_name} ({n_entries:,} entries)",
+            flush=True,
+        )
+
+        del results, weights_dict
+        gc.collect()
+
+    print(f"[rank {hvd.rank()}] finished all assigned batches", flush=True)
     
 
 if __name__ == "__main__":

--- a/scripts/save_unfolded_weights.py
+++ b/scripts/save_unfolded_weights.py
@@ -221,7 +221,7 @@ def main():
         batch_start = batch_idx * batch_size
         batch_end = min(batch_start + batch_size, total_events)
 
-    print(f"[rank {hvd.rank()}] processing batch {batch_idx} events [{batch_start}, {batch_end})", flush=True)
+        print(f"[rank {hvd.rank()}] processing batch {batch_idx} events [{batch_start}, {batch_end})", flush=True)
 
         if "data" not in flags.file:
             weights_dict = load_weights_slice(flags, batch_start, batch_end)

--- a/scripts/save_unfolded_weights.py
+++ b/scripts/save_unfolded_weights.py
@@ -21,7 +21,7 @@ def parse_arguments():
     )
     parser.add_argument(
         "--output_folder",
-        default="/global/cfs/cdirs/m3246/rmilton/tanvi_batching/test_data/",
+        default="/pscratch/sd/t/twamorka/h1/batchfiles/",
         help="",
     )
     parser.add_argument(

--- a/scripts/save_unfolded_weights.py
+++ b/scripts/save_unfolded_weights.py
@@ -218,7 +218,7 @@ def main():
     replace_string = f"unfolded_niter_{flags.niter}"
     if flags.reco:
         replace_string += "_reco"
-    if flags.bootstrap:
+    if flags.bootstrap and "Rapgap" in flags.file:
         replace_string += "_boot"
 
     # Each rank independently processes the batch assigned to it.

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -266,38 +266,6 @@ def get_sample_name(base_name, dataset, extension="_prep.h5"):
     print(f"sample name: {sample_name}")
     return sample_name
 
-# Rapgap_Eplus0607_unfolded_niter_4.h5
-
-def get_sample_name_weights(dataset="ep", niter="4"):
-    """
-    Returns MC filenames for Rapgap and Djangoh in a dictionary usable by dataloaders.
-    Example return value:
-        {
-            "Rapgap":  "Rapgap_Eplus0607_prep.h5",
-            "Djangoh": "Djangoh_Eplus0607_prep.h5"
-        }
-    """
-
-    assert dataset in ["ep", "em"], (
-        "ERROR: Datasets must be 'ep' (positron) or 'em' (electron)."
-    )
-
-    # Map ep/em to dataset tag
-    dataset_tag = "Eplus0607" if dataset == "ep" else "Eminus06"
-    extension = "_unfolded_niter_"+str(niter)+".h5"
-    # Construct both filenames
-    rapgap = f"Rapgap_{dataset_tag}{extension}"
-    djangoh = f"Djangoh_{dataset_tag}{extension}"
-
-    print("MC sample names:")
-    print("  Rapgap  →", rapgap)
-    print("  Djangoh →", djangoh)
-
-    return {
-        "Rapgap": rapgap,
-        "Djangoh": djangoh
-    }
-
 
 def LoadJson(file_name, base_path="../JSON"):
     JSONPATH = os.path.join(base_path, file_name)

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -390,6 +390,7 @@ def HistRoutine(
     weights=None,
     uncertainty=None,
     stat_uncertainty=None,
+    show_stat_points=True,
 ):
     """
     Generate a histogram plot with optional ratio and uncertainties.
@@ -551,7 +552,7 @@ def HistRoutine(
     )
 
     ## draw data points at 1 with stat uncertainties on the bottom panel
-    if "data" in reference_name.lower():
+    if show_stat_points:
         ax1.errorbar(
             xaxis,
             np.ones_like(xaxis),
@@ -644,6 +645,7 @@ def HistRoutinePart(
     weights=None,
     uncertainty=None,
     stat_uncertainty=None,
+    show_stat_points=True,
 ):
     """
     Generate a histogram plot with optional ratio and uncertainties.
@@ -805,7 +807,7 @@ def HistRoutinePart(
     )
 
     ## draw data points at 1 with stat uncertainties on the bottom panel
-    if "data" in reference_name.lower():
+    if show_stat_points:
         ax1.errorbar(
             xaxis,
             np.ones_like(xaxis),

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -264,7 +264,41 @@ def get_sample_name(base_name, dataset, extension="_prep.h5"):
 
     dataset = "Eplus0607" if dataset == "ep" else "Eminus06"
     sample_name = f"{base_name}_{dataset}{sys_name}{extension}"
+
+    print(f"sample name: {sample_name}")
     return sample_name
+
+# Rapgap_Eplus0607_unfolded_niter_4.h5
+
+def get_sample_name_weights(dataset="ep", niter="4"):
+    """
+    Returns MC filenames for Rapgap and Djangoh in a dictionary usable by dataloaders.
+    Example return value:
+        {
+            "Rapgap":  "Rapgap_Eplus0607_prep.h5",
+            "Djangoh": "Djangoh_Eplus0607_prep.h5"
+        }
+    """
+
+    assert dataset in ["ep", "em"], (
+        "ERROR: Datasets must be 'ep' (positron) or 'em' (electron)."
+    )
+
+    # Map ep/em to dataset tag
+    dataset_tag = "Eplus0607" if dataset == "ep" else "Eminus06"
+    extension = "_unfolded_niter_"+str(niter)+".h5"
+    # Construct both filenames
+    rapgap = f"Rapgap_{dataset_tag}{extension}"
+    djangoh = f"Djangoh_{dataset_tag}{extension}"
+
+    print("MC sample names:")
+    print("  Rapgap  →", rapgap)
+    print("  Djangoh →", djangoh)
+
+    return {
+        "Rapgap": rapgap,
+        "Djangoh": djangoh
+    }
 
 
 def LoadJson(file_name, base_path="../JSON"):
@@ -870,17 +904,54 @@ def undo_standardizing(flags, dataloaders):
 #     return mc_file_names
 
 
+# def get_version(dataset, flags, opt):
+#     version = opt["NAME"]
+#     if "sys" in dataset:
+#         match = re.search(r"sys(\d+)", dataset)
+#         version += f"_sys{match.group(1)}"
+#     if "Djangoh" in dataset:
+#         # Djangoh used for model uncertainty
+#         version += "_sys_model"
+#     version += f"_{dataset}"
+
+#     # version += f"_{flags.dataset}"
+#     if flags.load_pretrain:
+#         version += "_pretrained"
+#     return version
+
 def get_version(dataset, flags, opt):
-    version = opt["NAME"]
+    """Generate version string for model loading"""
+    version = opt["NAME"]  # This should be "H1_May2025"
+    
+    # Extract dataset type (ep/em) from filename
+    if "Eplus" in dataset or "ep" in dataset.lower():
+        dataset_type = "ep"
+    elif "Eminus" in dataset or "em" in dataset.lower():
+        dataset_type = "em" 
+    else:
+        # Fallback - extract from filename
+        if "Eplus0607" in dataset:
+            dataset_type = "ep"
+        elif "Eminus06" in dataset:
+            dataset_type = "em"
+        else:
+            dataset_type = "ep"  # Default fallback
+    
+    # Handle systematic variations
     if "sys" in dataset:
         match = re.search(r"sys(\d+)", dataset)
-        version += f"_sys{match.group(1)}"
+        if match:
+            version += f"_sys{match.group(1)}"
+    
     if "Djangoh" in dataset:
-        # Djangoh used for model uncertainty
         version += "_sys_model"
-    version += f"_{flags.dataset}"
-    if flags.load_pretrain:
-        version += "_pretrained"
+    
+    # Add dataset type (ep/em)
+    version += f"_{dataset_type}"
+    
+    # if flags.load_pretrain:
+    #     version += "_pretrained"
+        
     return version
 
 
@@ -889,7 +960,7 @@ def evaluate_model(
 ):
     if version is None:
         version = get_version(dataset, flags, opt)
-
+    print(f"version: {version}")
     model_name = "{}/OmniFold_{}_iter{}_step2/checkpoint".format(
         flags.weights, version, flags.niter
     )
@@ -897,7 +968,7 @@ def evaluate_model(
         model_name = "{}/OmniFold_{}_iter{}_step2_strap{}/checkpoint".format(
             flags.weights, version, flags.niter, nboot
         )
-
+    print(f"model name: {model_name}")
     if hvd.rank() == 0:
         print("Loading model {}".format(model_name))
 


### PR DESCRIPTION
New scripts:
- save_unfolded_weights.py : Reads a pre-evaluated unfolded weights file (from evaluate.py), clusters jets, computes observables and writes results to per-batch HDF5 files. Each MPI rank processes one independent batch, enabling parallelism across CPU nodes. Supports nominal weights, bootstrap replicas, and closure weights.
- plot_from_batches.py : Memory-efficient plotting that iterates over the batch HDF5 files produced above and accumulates weighted histograms. Replicates the full systematics treatment from the standard plotting code.

Changes to existing scripts:
- dataloader.py: Added global_start parameter so each rank loads only its assigned batch window
- plot_utils.py: parallelised jet clustering via a multiprocessing worker pool
- utils.py: minor changes
- Updated README.md